### PR TITLE
Implement GET /rounds/:round_id/contributors

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -5,7 +5,7 @@
 class ContributorsController < ApplicationController
   skip_before_filter :authenticate_from_token!
 
-  api :GET, 'rounds/:round_id/contributors/:user_id',
+  api :GET, '/rounds/:round_id/contributors/:user_id',
             'Get a contributor\'s details for a given round'
   def show
     round
@@ -19,6 +19,30 @@ class ContributorsController < ApplicationController
     render json: { contributor: {
       allocation_amount_cents: alloc_amt,
       contributions: contributions } }
+  end
+
+  api :GET, '/rounds/:round_id/contributors/',
+            'Gets all contributor\'s details for a given round'
+  def index
+    allocations = round.allocations.order('amount_cents DESC')
+    members_without_allocations = round.group.members.order('name ASC').where('users.id not in (?)', allocations.map{|a| a.user_id})
+    contributors = []
+    allocations.each do |allocation|
+      contributions = Contribution.for_round(params[:round_id])
+                                  .where(user_id: allocation.user_id)
+      contributors << {
+        user: UserSerializer.new(allocation.user).attributes,
+        allocation: AllocationSerializer.new(allocation).attributes,
+        contributions: ActiveModel::ArraySerializer.new(contributions, each_serializer: ContributionShortSerializer)
+      }
+    end
+    members_without_allocations.each do |member|
+      contributors << {
+        user: UserSerializer.new(member).attributes,
+        allocation: nil
+      }
+    end
+    render json: { contributors: contributors }
   end
 
   private

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -4,4 +4,5 @@ class Allocation < ActiveRecord::Base
 
   validates :round_id, presence: true
   validates :user_id, presence: true, uniqueness: {scope: :round}
+  validates :amount_cents, presence: true
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,6 +2,7 @@ class Group < ActiveRecord::Base
   has_many :rounds, dependent: :destroy
   has_one  :latest_round, class_name: 'Round', order: "id DESC"
   has_many :memberships
+  has_many :members, through: :memberships, source: :user
 
   def latest_round_id
     latest_round.id if latest_round

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -1,4 +1,3 @@
 class AllocationSerializer < ActiveModel::Serializer
-  attributes :amount_cents, :round_id
-  has_one :user
+  attributes :amount_cents, :round_id, :user_id
 end

--- a/app/serializers/contribution_short_serializer.rb
+++ b/app/serializers/contribution_short_serializer.rb
@@ -1,0 +1,3 @@
+class ContributionShortSerializer < ActiveModel::Serializer
+  attributes :id, :amount_cents, :user_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   resources :rounds, only: [:show, :create], defaults: { format: :json } do
     resources :allocations, only: [:index]
     resources :fixed_costs, only: [:index]
-    resources :contributors, only: [:show]
+    resources :contributors, only: [:show, :index]
   end
 
   # NOTE (JL): Added unsed show route here cause otherwise respond_with doesn't work

--- a/spec/factories/buckets.rb
+++ b/spec/factories/buckets.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :bucket do
+    name { Faker::Company.name }
+    round
+    user
+    target_cents 50000
+  end
+end

--- a/spec/factories/contributions.rb
+++ b/spec/factories/contributions.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :contribution do
+    user
+    bucket
+    amount_cents 100
+  end
+end

--- a/spec/requests/contributors_spec.rb
+++ b/spec/requests/contributors_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe "Memberships" do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:round) { FactoryGirl.create(:round) }
+
+  let(:request_headers) { {
+    "Accept" => "application/json",
+    "Content-Type" => "application/json",
+    "X-User-Token" => user.authentication_token,
+    "X-User-Email" => user.email,
+  } }
+
+  describe "GET /rounds/:round_id/contributors/" do
+    it "displays contributors information for given round" do
+      membership = FactoryGirl.create(:membership, group: round.group)
+      allocation = FactoryGirl.create(:allocation, round: round, amount_cents: 250)
+      allocation2 = FactoryGirl.create(:allocation, round: round, amount_cents: 500)
+      bucket = FactoryGirl.create(:bucket, round: round)
+      bucket2 = FactoryGirl.create(:bucket, round: round)
+      contribution = FactoryGirl.create(:contribution, bucket: bucket, user: allocation2.user, amount_cents: 100)
+      contribution2 = FactoryGirl.create(:contribution, bucket: bucket2, user: allocation2.user, amount_cents: 200)
+
+      get "/rounds/#{round.id}/contributors/", {}, request_headers
+
+      expect(response.status).to eq 200 # success
+
+      body = JSON.parse(response.body)
+
+      #
+      # Contributors ordered by highest allocation first
+      #
+
+      expect(body["contributors"][0]["allocation"]["amount_cents"]).to eq 500
+      expect(body["contributors"][0]["user"]["id"]).to eq allocation2.user_id
+
+      # Contributor's contributions ordered highest to lowest
+      expect(body["contributors"][0]["contributions"][0]["amount_cents"]).to eq contribution2.amount_cents
+      expect(body["contributors"][0]["contributions"][1]["amount_cents"]).to eq contribution.amount_cents
+
+      expect(body["contributors"][1]["allocation"]["amount_cents"]).to eq 250
+      expect(body["contributors"][1]["user"]["id"]).to eq allocation.user_id
+
+      # Contributors without allocations come last
+      expect(body["contributors"][2]["allocation"]).to eq nil
+      expect(body["contributors"][2]["user"]["id"]).to eq membership.user_id
+    end
+  end
+end


### PR DESCRIPTION
Returns with the following format (I know there's a lot of redundant data but we can deal with that later):

```
{"contributors"=>
  [{"user"=>{"id"=>308, "name"=>"Summer Rogahn"},
    "allocation"=>{"amount_cents"=>500, "round_id"=>163, "user_id"=>308},
    "contributions"=>
     [{"id"=>26,
       "amount_cents"=>200,
       "user_id"=>308,
       "created_at"=>"2014-11-29T03:22:28.715Z"},
      {"id"=>25,
       "amount_cents"=>100,
       "user_id"=>308,
       "created_at"=>"2014-11-29T03:22:28.711Z"}]},
   {"user"=>{"id"=>307, "name"=>"Mr. Adriana Bernier"},
    "allocation"=>{"amount_cents"=>250, "round_id"=>163, "user_id"=>307},
    "contributions"=>[]},
   {"user"=>{"id"=>306, "name"=>"Shanelle Gleason"}, "allocation"=>nil}]}
```
