### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/open-app/cobudget-api.png?label=ready&title=Ready)](https://waffle.io/open-app/cobudget-api)
 # Cobudget! backend interface
 
 [![Code Climate](https://codeclimate.com/github/enspiral/cobudget-api.png)](https://codeclimate.com/github/enspiral/cobudget-api)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/open-app/cobudget-api

This was requested by a real person (user joshuavial) on waffle.io, we're not trying to spam you.
