### PR TITLE
Remove duplicate airbrake entries in the Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'omniauth'
 gem 'puma'
 gem 'delayed_job_active_record'
 gem 'daemons'
-gem 'airbrake'
 gem 'sinatra', :require => nil
 
 # error tracking


### PR DESCRIPTION
This fixes a warning thrown by bundler. This addresses github issue https://github.com/cobudget/cobudget-api/issues/91.