### PR TITLE
Feature/email digest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'database_cleaner'
   gem 'simplecov', :require => false
+  gem 'timecop'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
+    timecop (0.7.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     warden (1.2.3)
@@ -262,3 +263,4 @@ DEPENDENCIES
   simplecov
   sinatra
   spring
+  timecop

--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -15,7 +15,7 @@ class BucketsController < AuthenticatedController
   def create
     bucket = Bucket.new(bucket_params_create)
     if bucket.save
-      BucketService.send_bucket_created_emails(bucket: bucket, current_user: current_user)
+      # BucketService.send_bucket_created_emails(bucket: bucket, current_user: current_user)
       render json: [bucket]
     else 
       render json: {
@@ -45,7 +45,7 @@ class BucketsController < AuthenticatedController
   def open_for_funding
     bucket = Bucket.find(params[:id])
     bucket.open_for_funding(target: params[:target], funding_closes_at: params[:funding_closes_at])
-    BucketService.send_bucket_live_emails(bucket: bucket, current_user: current_user)
+    # BucketService.send_bucket_live_emails(bucket: bucket, current_user: current_user)
     render json: [bucket]
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,7 @@ class UsersController < AuthenticatedController
 
   api :POST, '/users?invite_group'
   def create
+    # TODO: only an admin should be able to create a user
     user = User.create_with_confirmation_token(email: user_params[:email])
     if user.valid?
       UserMailer.invite_new_group_email(user: user, inviter: current_user).deliver_later

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < AuthenticatedController
 
-  skip_before_action :authenticate_user!, except: :create
+  skip_before_action :authenticate_user!, except: [:create, :update_profile]
 
   api :POST, '/users/confirm_account'
   def confirm_account
@@ -22,6 +22,12 @@ class UsersController < AuthenticatedController
     else
       render status: 409, nothing: true
     end
+  end
+
+  api :POST, '/users/update_profile'
+  def update_profile
+    current_user.update(user_params)
+    render json: [current_user]
   end
 
   api :POST, '/users/request_password_reset?email'
@@ -53,6 +59,6 @@ class UsersController < AuthenticatedController
 
   private
     def user_params
-      params.require(:user).permit(:email)
+      params.require(:user).permit(:email, :utc_offset)
     end
 end

--- a/app/extras/deliver_daily_email_digest.rb
+++ b/app/extras/deliver_daily_email_digest.rb
@@ -7,9 +7,7 @@ class DeliverDailyEmailDigest
     end
 
     User.where(utc_offset: unique_utc_offsets).find_each do |user|
-      if recent_activity = UserService.fetch_recent_activity_for(user: user)
-        UserMailer.daily_email_digest(user: user, recent_activity: recent_activity).deliver_later
-      end
+      UserMailer.daily_email_digest(user: user).deliver_later
     end
   end
 end

--- a/app/extras/deliver_daily_email_digest.rb
+++ b/app/extras/deliver_daily_email_digest.rb
@@ -6,7 +6,7 @@ class DeliverDailyEmailDigest
       (Time.now.utc + utc_offset.minutes).hour == 6 if utc_offset
     end
 
-    User.where(utc_offset: unique_utc_offsets).find_each do |user|
+    User.where(utc_offset: unique_utc_offsets, subscribed_to_daily_digest: true).find_each do |user|
       UserMailer.daily_email_digest(user: user).deliver_later
     end
   end

--- a/app/extras/deliver_daily_email_digest.rb
+++ b/app/extras/deliver_daily_email_digest.rb
@@ -1,0 +1,12 @@
+class DeliverDailyEmailDigest
+  def self.to_subscribers!
+    unique_utc_offsets = User.pluck('DISTINCT utc_offset').select do |utc_offset|
+      (Time.now.utc + utc_offset.minutes).hour == 6
+    end
+
+    User.where(utc_offset: unique_utc_offsets).find_each do |user|
+      recent_activity = UserService.fetch_recent_activity_for(user: user)
+      UserMailer.daily_email_digest(user: user, recent_activity: recent_activity).deliver_later
+    end
+  end
+end

--- a/app/extras/deliver_daily_email_digest.rb
+++ b/app/extras/deliver_daily_email_digest.rb
@@ -5,8 +5,9 @@ class DeliverDailyEmailDigest
     end
 
     User.where(utc_offset: unique_utc_offsets).find_each do |user|
-      recent_activity = UserService.fetch_recent_activity_for(user: user)
-      UserMailer.daily_email_digest(user: user, recent_activity: recent_activity).deliver_later
+      if recent_activity = UserService.fetch_recent_activity_for(user: user)
+        UserMailer.daily_email_digest(user: user, recent_activity: recent_activity).deliver_later
+      end
     end
   end
 end

--- a/app/extras/deliver_daily_email_digest.rb
+++ b/app/extras/deliver_daily_email_digest.rb
@@ -1,4 +1,6 @@
 class DeliverDailyEmailDigest
+  # TODO LATER: scope this to users who have actually subscribed to the digest
+  # until the email settings feature is complete, email digest will be default
   def self.to_subscribers!
     unique_utc_offsets = User.pluck('DISTINCT utc_offset').select do |utc_offset|
       (Time.now.utc + utc_offset.minutes).hour == 6 if utc_offset

--- a/app/extras/deliver_daily_email_digest.rb
+++ b/app/extras/deliver_daily_email_digest.rb
@@ -1,7 +1,7 @@
 class DeliverDailyEmailDigest
   def self.to_subscribers!
     unique_utc_offsets = User.pluck('DISTINCT utc_offset').select do |utc_offset|
-      (Time.now.utc + utc_offset.minutes).hour == 6
+      (Time.now.utc + utc_offset.minutes).hour == 6 if utc_offset
     end
 
     User.where(utc_offset: unique_utc_offsets).find_each do |user|

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,13 +1,3 @@
-module ActionMailer
-  class Base
-    def do_not_deliver
-      def self.deliver
-        false
-      end
-    end
-  end
-end
-
 class UserMailer < ActionMailer::Base
   def invite_email(user: , group: , inviter: , initial_allocation_amount:)
     @user = user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -142,6 +142,7 @@ class UserMailer < ActionMailer::Base
   def daily_email_digest(user: , recent_activity:)
     @user = user 
     @recent_activity = recent_activity
+    @formatted_date_today = DateTime.now.in_time_zone(user.utc_offset / 60).strftime("%A, %B %d")
     mail(to: user.name_and_email,
          from: "Cobudget Updates <updates@cobudget.co>",
          subject: "its an email digest")

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -145,7 +145,7 @@ class UserMailer < ActionMailer::Base
     if @recent_activity = UserService.fetch_recent_activity_for(user: user)
       mail(to: user.name_and_email,
            from: "Cobudget Updates <updates@cobudget.co>",
-           subject: "its an email digest")
+           subject: "[Cobudget] Daily Summary - New activity in your groups")
     end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,3 +1,13 @@
+module ActionMailer
+  class Base
+    def do_not_deliver
+      def self.deliver
+        false
+      end
+    end
+  end
+end
+
 class UserMailer < ActionMailer::Base
   def invite_email(user: , group: , inviter: , initial_allocation_amount:)
     @user = user
@@ -139,12 +149,13 @@ class UserMailer < ActionMailer::Base
          subject: subject)
   end
 
-  def daily_email_digest(user: , recent_activity:)
+  def daily_email_digest(user:)
     @user = user 
-    @recent_activity = recent_activity
     @formatted_date_today = DateTime.now.in_time_zone(user.utc_offset / 60).strftime("%A, %B %d")
-    mail(to: user.name_and_email,
-         from: "Cobudget Updates <updates@cobudget.co>",
-         subject: "its an email digest")
+    if @recent_activity = UserService.fetch_recent_activity_for(user: user)
+      mail(to: user.name_and_email,
+           from: "Cobudget Updates <updates@cobudget.co>",
+           subject: "its an email digest")
+    end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -138,4 +138,11 @@ class UserMailer < ActionMailer::Base
          from: "Cobudget Accounts <accounts@cobudget.co>",
          subject: subject)
   end
+
+  def daily_email_digest(user:)
+    @user = user 
+    mail(to: user.name_and_email,
+         from: "Cobudget Updates <updates@cobudget.co>",
+         subject: "its an email digest")
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -140,7 +140,7 @@ class UserMailer < ActionMailer::Base
   end
 
   def daily_email_digest(user:)
-    @user = user 
+    @user = user
     @formatted_date_today = DateTime.now.in_time_zone(user.utc_offset / 60).strftime("%A, %B %d")
     if @recent_activity = UserService.fetch_recent_activity_for(user: user)
       mail(to: user.name_and_email,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -139,8 +139,9 @@ class UserMailer < ActionMailer::Base
          subject: subject)
   end
 
-  def daily_email_digest(user:)
+  def daily_email_digest(user: , recent_activity:)
     @user = user 
+    @recent_activity = recent_activity
     mail(to: user.name_and_email,
          from: "Cobudget Updates <updates@cobudget.co>",
          subject: "its an email digest")

--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -37,6 +37,10 @@ class Bucket < ActiveRecord::Base
     total_contributions == target
   end
 
+  def formatted_percent_funded
+    "#{(total_contributions / target.to_f).to_i * 100}%"
+  end
+
   def num_of_comments
     comments.length
   end

--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -38,7 +38,7 @@ class Bucket < ActiveRecord::Base
   end
 
   def formatted_percent_funded
-    "#{(total_contributions / target.to_f).to_i * 100}%"
+    "#{((total_contributions / target).to_f * 100).round}%"
   end
 
   def num_of_comments

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -26,6 +26,10 @@ class Group < ActiveRecord::Base
     allocation_sum - contribution_sum
   end
 
+  def formatted_balance
+    Money.new(balance * 100, currency_code).format
+  end
+
   private 
     def update_currency_symbol_if_currency_code_changed
       if self.currency_code

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
   embed :ids, include: true
-  attributes :id, :name, :email
+  attributes :id, :name, :email, :utc_offset
 end

--- a/app/services/bucket_service.rb
+++ b/app/services/bucket_service.rb
@@ -23,9 +23,9 @@ class BucketService
     if bucket_author && bucket_author.subscribed_to_personal_activity
       UserMailer.notify_author_that_bucket_is_funded(bucket: bucket).deliver_later
     end
-    members = bucket.group.members.reject { |member| member == bucket_author }
-    members.each do |member|
-      UserMailer.notify_member_that_bucket_is_funded(bucket: bucket, member: member).deliver_later
-    end
+    # members = bucket.group.members.reject { |member| member == bucket_author }
+    # members.each do |member|
+    #   UserMailer.notify_member_that_bucket_is_funded(bucket: bucket, member: member).deliver_later
+    # end
   end
 end

--- a/app/services/bucket_service.rb
+++ b/app/services/bucket_service.rb
@@ -19,8 +19,10 @@ class BucketService
   end
 
   def self.send_bucket_funded_emails(bucket: )
-    UserMailer.notify_author_that_bucket_is_funded(bucket: bucket).deliver_later
     bucket_author = bucket.user
+    if bucket_author && bucket_author.subscribed_to_personal_activity
+      UserMailer.notify_author_that_bucket_is_funded(bucket: bucket).deliver_later
+    end
     members = bucket.group.members.reject { |member| member == bucket_author }
     members.each do |member|
       UserMailer.notify_member_that_bucket_is_funded(bucket: bucket, member: member).deliver_later

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -5,7 +5,7 @@ class CommentService
     comment_author = comment.user
 
     # in case bucket_author was deleted
-    if bucket_author && bucket_author != comment_author
+    if bucket_author && bucket_author != comment_author && bucket_author.subscribed_to_personal_activity
       UserMailer.notify_author_of_new_comment_email(comment: comment).deliver_later
     end
 

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -13,8 +13,7 @@ class CommentService
 
     funders =  User.joins(:contributions).where(contributions: {bucket_id: bucket.id}).uniq
 
-    users_to_notify = (commenters + funders).uniq.reject { |member| member == comment_author || member == bucket_author }
-
-    users_to_notify.each { |user| UserMailer.notify_user_of_new_comment_email(comment: comment, user: user).deliver_later } 
+    # users_to_notify = (commenters + funders).uniq.reject { |member| member == comment_author || member == bucket_author }
+    # users_to_notify.each { |user| UserMailer.notify_user_of_new_comment_email(comment: comment, user: user).deliver_later } 
   end
 end

--- a/app/services/contribution_service.rb
+++ b/app/services/contribution_service.rb
@@ -4,7 +4,7 @@ class ContributionService
     bucket = contribution.bucket
     bucket_author = bucket.user
 
-    unless funder == bucket_author
+    if bucket_author && funder != bucket_author && bucket_author.subscribed_to_personal_activity
       UserMailer.notify_author_that_bucket_received_contribution(contribution: contribution).deliver_later
     end
 

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,0 +1,5 @@
+class UserService
+  def self.set_utc_offset(user: , utc_offset:)
+    user.update(utc_offset: utc_offset)
+  end
+end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,15 +1,18 @@
 class UserService
   def self.fetch_recent_activity_for(user:)
+    return nil unless user.utc_offset
     user_utc_offset_in_hours = user.utc_offset / 60
     user_6am_today_in_utc = (DateTime.now.in_time_zone(user_utc_offset_in_hours).beginning_of_day + 6.hours).utc 
     user_6am_yesterday_in_utc = user_6am_today_in_utc - 1.day
 
-    user.groups.map do |group|
+    user.memberships.map do |membership|
+      group = membership.group
       draft_buckets = Bucket.where(group: group, status: 'draft', created_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
       live_buckets = Bucket.where(group: group, status: 'live', live_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
       funded_buckets = Bucket.where(group: group, status: 'funded', funded_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
       {
         group: group,
+        membership: membership,
         draft_buckets: draft_buckets,
         live_buckets: live_buckets,
         funded_buckets: funded_buckets

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,5 +1,5 @@
 class UserService
-  def self.fetch_recent_activity_for(user: user)
+  def self.fetch_recent_activity_for(user:)
     user_utc_offset_in_hours = user.utc_offset / 60
     user_6am_today_in_utc = (DateTime.now.in_time_zone(user_utc_offset_in_hours).beginning_of_day + 6.hours).utc 
     user_6am_yesterday_in_utc = user_6am_today_in_utc - 1.day

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,5 +1,19 @@
 class UserService
-  def self.set_utc_offset(user: , utc_offset:)
-    user.update(utc_offset: utc_offset)
+  def self.fetch_recent_activity_for(user: user)
+    user_utc_offset_in_hours = user.utc_offset / 60
+    user_6am_today_in_utc = (DateTime.now.in_time_zone(user_utc_offset_in_hours).beginning_of_day + 6.hours).utc 
+    user_6am_yesterday_in_utc = user_6am_today_in_utc - 1.day
+
+    user.groups.map do |group|
+      draft_buckets = Bucket.where(group: group, status: 'draft', created_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
+      live_buckets = Bucket.where(group: group, status: 'live', live_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
+      funded_buckets = Bucket.where(group: group, status: 'funded', funded_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
+      {
+        group: group,
+        draft_buckets: draft_buckets,
+        live_buckets: live_buckets,
+        funded_buckets: funded_buckets
+      }
+    end
   end
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -5,7 +5,7 @@ class UserService
     user_6am_today_in_utc = (DateTime.now.in_time_zone(user_utc_offset_in_hours).beginning_of_day + 6.hours).utc 
     user_6am_yesterday_in_utc = user_6am_today_in_utc - 1.day
 
-    user.memberships.map do |membership|
+    recent_activity = user.memberships.map do |membership|
       group = membership.group
       draft_buckets = Bucket.where(group: group, status: 'draft', created_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
       live_buckets = Bucket.where(group: group, status: 'live', live_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
@@ -18,5 +18,9 @@ class UserService
         funded_buckets: funded_buckets
       }
     end
+
+    recent_activity.select! { |a| a[:draft_buckets].any? || a[:live_buckets].any? || a[:funded_buckets].any? }
+
+    recent_activity if recent_activity.any?
   end
 end

--- a/app/views/user_mailer/daily_email_digest.html.erb
+++ b/app/views/user_mailer/daily_email_digest.html.erb
@@ -1,0 +1,47 @@
+<p>Cobudget Daily Summary</p>
+
+<p> <%= @time_now_formatted %> </p>
+
+<p>Hi! Here's a summary of what happened in your Cobudget groups yesterday:</p>
+
+<p>---</p>
+
+<% @user.memberships.each do |membership| %>
+  <% group = membership.group %>
+  <% new_draft_buckets = group.buckets.where(status: 'draft', created_at > @user.last_email_digest_sent_at) %>
+  <% new_live_buckets = group.buckets.where(status: 'live', live_at > @user.last_email_digest_sent_at) %>
+  <% new_funded_buckets = group.buckets.where(status: 'funded', funded_at > @user.last_email_digest_sent_at) %>
+
+  <p><b><%= link_to group.name, "#{root_url}#/groups/#{group.id}" %></b> has <%= group.formatted_balance %> to spend together. You have <%= membership.formatted_balance %> to spend.</p>
+
+  <b><%= new_draft_buckets.length %> New bucket <%= pluralize(new_draft_buckets.length, 'idea') %></b><br/>
+  <ul>
+    <% new_draft_buckets.each do |bucket| %>
+      <li>
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %>
+      </li>
+    <% end %>
+  </ul>
+
+  <b><%= new_live_buckets.length %> New <%= pluralize(new_live_buckets.length, 'bucket') %> funding</b><br/>
+  <ul>
+    <% new_live_buckets.each do |bucket| %>
+      <li>
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.percent_funded %>% funded)
+      </li>
+    <% end %>
+  </ul>
+
+  <b><%= new_funded_buckets.length %> New <%= pluralize(new_funded_buckets.length, 'bucket') %> funded</b><br/>
+  <ul>
+    <% new_funded_buckets.each do |bucket| %>
+      <li>
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> ($<%= @bucket.formatted_target %>)
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<p>Do you have an idea you want to propose for funding? <%= link_to "Create it now", "#{root_url}#/buckets/new}" %></p>
+
+<p><%= "<3" %> from Cobudget</p>

--- a/app/views/user_mailer/daily_email_digest.html.erb
+++ b/app/views/user_mailer/daily_email_digest.html.erb
@@ -2,58 +2,49 @@
 
 <p><%= @formatted_date_today %></p>
 
-<% if @recent_activity %>
-  <p>Hi! Here's a summary of what happened in your Cobudget groups yesterday:</p>
+<p>Hi! Here's a summary of what happened in your Cobudget groups yesterday:</p>
+
+<p>---</p>
+
+<% @recent_activity.each do |activity| %>
+  <% group = activity[:group] %>
+  <% membership = activity[:membership] %>
+  <% draft_buckets = activity[:draft_buckets] %>
+  <% live_buckets = activity[:live_buckets] %>
+  <% funded_buckets = activity[:funded_buckets] %>
+
+  <p><b><%= link_to group.name, "#{root_url}#/groups/#{group.id}" %></b> has <%= group.formatted_balance %> to spend together. You have <%= membership.formatted_balance %> to spend.</p>
+
+  <b><%= draft_buckets.length %> New bucket <%= "idea".pluralize(draft_buckets.length) %></b><br/>
+  <ul>
+    <% draft_buckets.each do |bucket| %>
+      <li>
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %>
+      </li>
+    <% end %>
+  </ul>
+
+  <b><%= live_buckets.length %> New <%= "bucket".pluralize(live_buckets.length) %> funding</b><br/>
+  <ul>
+    <% live_buckets.each do |bucket| %>
+      <li>
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_percent_funded %> funded)
+      </li>
+    <% end %>
+  </ul>
+
+  <b><%= funded_buckets.length %> New <%= "bucket".pluralize(funded_buckets.length) %> funded</b><br/>
+  <ul>
+    <% funded_buckets.each do |bucket| %>
+      <li>
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_target %>)
+      </li>
+    <% end %>
+  </ul>
 
   <p>---</p>
-
-  <% @recent_activity.each do |activity| %>
-    <% group = activity[:group] %>
-    <% membership = activity[:membership] %>
-    <% draft_buckets = activity[:draft_buckets] %>
-    <% live_buckets = activity[:live_buckets] %>
-    <% funded_buckets = activity[:funded_buckets] %>
-
-    <p><b><%= link_to group.name, "#{root_url}#/groups/#{group.id}" %></b> has <%= group.formatted_balance %> to spend together. You have <%= membership.formatted_balance %> to spend.</p>
-
-    <b><%= draft_buckets.length %> New bucket <%= "idea".pluralize(draft_buckets.length) %></b><br/>
-    <ul>
-      <% draft_buckets.each do |bucket| %>
-        <li>
-          <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %>
-        </li>
-      <% end %>
-    </ul>
-
-    <b><%= live_buckets.length %> New <%= "bucket".pluralize(live_buckets.length) %> funding</b><br/>
-    <ul>
-      <% live_buckets.each do |bucket| %>
-        <li>
-          <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_percent_funded %> funded)
-        </li>
-      <% end %>
-    </ul>
-
-    <b><%= funded_buckets.length %> New <%= "bucket".pluralize(funded_buckets.length) %> funded</b><br/>
-    <ul>
-      <% funded_buckets.each do |bucket| %>
-        <li>
-          <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_target %>)
-        </li>
-      <% end %>
-    </ul>
-
-    <p>---</p>
-  <% end %>
-  
-<% else %>
-
-  <p>Hmm, not a lot happened yesterday.</p>
-
-  <iframe src="//giphy.com/embed/VqYyKYygtFvz2" width="480" height="293" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>
-    
 <% end %>
-
+  
 <p>Do you have an idea you want to propose for funding? <%= link_to "Create it now", "#{root_url}#/buckets/new" %></p>
 
 <p><%= "<3" %> from Cobudget</p>

--- a/app/views/user_mailer/daily_email_digest.html.erb
+++ b/app/views/user_mailer/daily_email_digest.html.erb
@@ -1,47 +1,51 @@
 <p>Cobudget Daily Summary</p>
 
-<p> <%= @time_now_formatted %> </p>
+<p><%= @formatted_date_today %></p>
 
 <p>Hi! Here's a summary of what happened in your Cobudget groups yesterday:</p>
 
 <p>---</p>
 
-<% @user.memberships.each do |membership| %>
-  <% group = membership.group %>
-  <% new_draft_buckets = group.buckets.where(status: 'draft', created_at > @user.last_email_digest_sent_at) %>
-  <% new_live_buckets = group.buckets.where(status: 'live', live_at > @user.last_email_digest_sent_at) %>
-  <% new_funded_buckets = group.buckets.where(status: 'funded', funded_at > @user.last_email_digest_sent_at) %>
+<% @recent_activity.each do |activity| %>
+  <% group = activity[:group] %>
+  <% membership = activity[:membership] %>
+  <% draft_buckets = activity[:draft_buckets] %>
+  <% live_buckets = activity[:live_buckets] %>
+  <% funded_buckets = activity[:funded_buckets] %>
 
   <p><b><%= link_to group.name, "#{root_url}#/groups/#{group.id}" %></b> has <%= group.formatted_balance %> to spend together. You have <%= membership.formatted_balance %> to spend.</p>
 
-  <b><%= new_draft_buckets.length %> New bucket <%= pluralize(new_draft_buckets.length, 'idea') %></b><br/>
+  <b><%= draft_buckets.length %> New bucket <%= "idea".pluralize(draft_buckets.length) %></b><br/>
   <ul>
-    <% new_draft_buckets.each do |bucket| %>
+    <% draft_buckets.each do |bucket| %>
       <li>
         <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %>
       </li>
     <% end %>
   </ul>
 
-  <b><%= new_live_buckets.length %> New <%= pluralize(new_live_buckets.length, 'bucket') %> funding</b><br/>
+  <b><%= live_buckets.length %> New <%= "bucket".pluralize(live_buckets.length) %> funding</b><br/>
   <ul>
-    <% new_live_buckets.each do |bucket| %>
+    <% live_buckets.each do |bucket| %>
       <li>
-        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.percent_funded %>% funded)
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_percent_funded %> funded)
       </li>
     <% end %>
   </ul>
 
-  <b><%= new_funded_buckets.length %> New <%= pluralize(new_funded_buckets.length, 'bucket') %> funded</b><br/>
+  <b><%= funded_buckets.length %> New <%= "bucket".pluralize(funded_buckets.length) %> funded</b><br/>
   <ul>
-    <% new_funded_buckets.each do |bucket| %>
+    <% funded_buckets.each do |bucket| %>
       <li>
-        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> ($<%= @bucket.formatted_target %>)
+        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_target %>)
       </li>
     <% end %>
   </ul>
+
+  <p>---</p>
 <% end %>
 
-<p>Do you have an idea you want to propose for funding? <%= link_to "Create it now", "#{root_url}#/buckets/new}" %></p>
+
+<p>Do you have an idea you want to propose for funding? <%= link_to "Create it now", "#{root_url}#/buckets/new" %></p>
 
 <p><%= "<3" %> from Cobudget</p>

--- a/app/views/user_mailer/daily_email_digest.html.erb
+++ b/app/views/user_mailer/daily_email_digest.html.erb
@@ -2,49 +2,57 @@
 
 <p><%= @formatted_date_today %></p>
 
-<p>Hi! Here's a summary of what happened in your Cobudget groups yesterday:</p>
-
-<p>---</p>
-
-<% @recent_activity.each do |activity| %>
-  <% group = activity[:group] %>
-  <% membership = activity[:membership] %>
-  <% draft_buckets = activity[:draft_buckets] %>
-  <% live_buckets = activity[:live_buckets] %>
-  <% funded_buckets = activity[:funded_buckets] %>
-
-  <p><b><%= link_to group.name, "#{root_url}#/groups/#{group.id}" %></b> has <%= group.formatted_balance %> to spend together. You have <%= membership.formatted_balance %> to spend.</p>
-
-  <b><%= draft_buckets.length %> New bucket <%= "idea".pluralize(draft_buckets.length) %></b><br/>
-  <ul>
-    <% draft_buckets.each do |bucket| %>
-      <li>
-        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %>
-      </li>
-    <% end %>
-  </ul>
-
-  <b><%= live_buckets.length %> New <%= "bucket".pluralize(live_buckets.length) %> funding</b><br/>
-  <ul>
-    <% live_buckets.each do |bucket| %>
-      <li>
-        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_percent_funded %> funded)
-      </li>
-    <% end %>
-  </ul>
-
-  <b><%= funded_buckets.length %> New <%= "bucket".pluralize(funded_buckets.length) %> funded</b><br/>
-  <ul>
-    <% funded_buckets.each do |bucket| %>
-      <li>
-        <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_target %>)
-      </li>
-    <% end %>
-  </ul>
+<% if @recent_activity %>
+  <p>Hi! Here's a summary of what happened in your Cobudget groups yesterday:</p>
 
   <p>---</p>
-<% end %>
 
+  <% @recent_activity.each do |activity| %>
+    <% group = activity[:group] %>
+    <% membership = activity[:membership] %>
+    <% draft_buckets = activity[:draft_buckets] %>
+    <% live_buckets = activity[:live_buckets] %>
+    <% funded_buckets = activity[:funded_buckets] %>
+
+    <p><b><%= link_to group.name, "#{root_url}#/groups/#{group.id}" %></b> has <%= group.formatted_balance %> to spend together. You have <%= membership.formatted_balance %> to spend.</p>
+
+    <b><%= draft_buckets.length %> New bucket <%= "idea".pluralize(draft_buckets.length) %></b><br/>
+    <ul>
+      <% draft_buckets.each do |bucket| %>
+        <li>
+          <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %>
+        </li>
+      <% end %>
+    </ul>
+
+    <b><%= live_buckets.length %> New <%= "bucket".pluralize(live_buckets.length) %> funding</b><br/>
+    <ul>
+      <% live_buckets.each do |bucket| %>
+        <li>
+          <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_percent_funded %> funded)
+        </li>
+      <% end %>
+    </ul>
+
+    <b><%= funded_buckets.length %> New <%= "bucket".pluralize(funded_buckets.length) %> funded</b><br/>
+    <ul>
+      <% funded_buckets.each do |bucket| %>
+        <li>
+          <%= link_to bucket.name, "#{root_url}#/buckets/#{bucket.id}" %> (<%= bucket.formatted_target %>)
+        </li>
+      <% end %>
+    </ul>
+
+    <p>---</p>
+  <% end %>
+  
+<% else %>
+
+  <p>Hmm, not a lot happened yesterday.</p>
+
+  <iframe src="//giphy.com/embed/VqYyKYygtFvz2" width="480" height="293" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>
+    
+<% end %>
 
 <p>Do you have an idea you want to propose for funding? <%= link_to "Create it now", "#{root_url}#/buckets/new" %></p>
 

--- a/app/views/user_mailer/daily_email_digest.html.erb
+++ b/app/views/user_mailer/daily_email_digest.html.erb
@@ -1,8 +1,6 @@
-<p>Cobudget Daily Summary</p>
+<p>Hi!</p>
 
-<p><%= @formatted_date_today %></p>
-
-<p>Hi! Here's a summary of what happened in your Cobudget groups yesterday:</p>
+<p>Here's a summary of what happened in your Cobudget groups yesterday:</p>
 
 <p>---</p>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,7 @@ module CobudgetApi
     config.active_job.queue_adapter = :delayed_job
 
     config.eager_load_paths += %W( #{config.root}/services )
+    config.eager_load_paths += %W( #{config.root}/extras )
 
     ActiveSupport.encode_big_decimal_as_string = false
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module CobudgetApi
 
     config.eager_load_paths += %W( #{config.root}/services )
     config.eager_load_paths += %W( #{config.root}/extras )
+    config.eager_load_paths += %W( #{config.root}/lib/core_ext )
 
     ActiveSupport.encode_big_decimal_as_string = false
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,7 +32,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
-  config.active_job.queue_adapter = :test
+  # commented out because it is overriding application.rb active_job.queue_adapter = :delayed_job
+  # config.active_job.queue_adapter = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,2 +1,5 @@
 Delayed::Worker.max_attempts = 2
-Delayed::Worker.delay_jobs = !(Rails.env.test? or Rails.env.development?)
+
+# (EL) commented out because i actually don't want scheduled jobs to execute immediately when i'm developing or testing.
+  # later on, i can probably make a test helper that causes all enqueued jobs to execute, if needed.
+# Delayed::Worker.delay_jobs = !(Rails.env.test? or Rails.env.development?)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         post :confirm_account
         post :request_password_reset
         post :reset_password
+        post :update_profile
       end
     end
 

--- a/db/migrate/20151104171710_add_utc_offset_to_users.rb
+++ b/db/migrate/20151104171710_add_utc_offset_to_users.rb
@@ -1,0 +1,5 @@
+class AddUtcOffsetToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :utc_offset, :integer, default: 0
+  end
+end

--- a/db/migrate/20151105204527_remove_default_utc_offset_from_users.rb
+++ b/db/migrate/20151105204527_remove_default_utc_offset_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultUtcOffsetFromUsers < ActiveRecord::Migration
+  def change
+    change_column_default :users, :utc_offset, nil
+  end
+end

--- a/db/migrate/20151107025819_add_subscribed_to_personal_activity_to_users.rb
+++ b/db/migrate/20151107025819_add_subscribed_to_personal_activity_to_users.rb
@@ -1,10 +1,10 @@
 class AddSubscribedToPersonalActivityToUsers < ActiveRecord::Migration
   def up
-    add_column :users, :add_subscribed_to_personal_activity, :boolean, default: true
-    User.all.each { |u| u.update(add_subscribed_to_personal_activity: true) }
+    add_column :users, :subscribed_to_personal_activity, :boolean, default: true
+    User.all.each { |u| u.update(subscribed_to_personal_activity: true) }
   end
 
   def down
-    remove_column :users, :add_subscribed_to_personal_activity    
+    remove_column :users, :subscribed_to_personal_activity    
   end
 end

--- a/db/migrate/20151107025819_add_subscribed_to_personal_activity_to_users.rb
+++ b/db/migrate/20151107025819_add_subscribed_to_personal_activity_to_users.rb
@@ -1,0 +1,10 @@
+class AddSubscribedToPersonalActivityToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :add_subscribed_to_personal_activity, :boolean, default: true
+    User.all.each { |u| u.update(add_subscribed_to_personal_activity: true) }
+  end
+
+  def down
+    remove_column :users, :add_subscribed_to_personal_activity    
+  end
+end

--- a/db/migrate/20151107030406_add_subscribed_to_daily_digest_to_users.rb
+++ b/db/migrate/20151107030406_add_subscribed_to_daily_digest_to_users.rb
@@ -1,0 +1,10 @@
+class AddSubscribedToDailyDigestToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :subscribed_to_daily_digest, :boolean, default: true
+    User.update_all(subscribed_to_daily_digest: true)
+  end
+
+  def down
+    remove_column :users, :subscribed_to_daily_digest, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151105204527) do
+ActiveRecord::Schema.define(version: 20151107030406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,12 +102,12 @@ ActiveRecord::Schema.define(version: 20151105204527) do
   add_index "memberships", ["member_id"], name: "index_memberships_on_member_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
+    t.string   "email",                               default: "",    null: false
+    t.string   "encrypted_password",                  default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer  "sign_in_count",                       default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -115,12 +115,14 @@ ActiveRecord::Schema.define(version: 20151105204527) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "name"
-    t.boolean  "initialized",            default: false, null: false
+    t.boolean  "initialized",                         default: false, null: false
     t.text     "tokens"
     t.string   "provider"
     t.string   "uid"
     t.string   "confirmation_token"
     t.integer  "utc_offset"
+    t.boolean  "add_subscribed_to_personal_activity", default: true
+    t.boolean  "subscribed_to_daily_digest",          default: true
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,12 +102,12 @@ ActiveRecord::Schema.define(version: 20151107030406) do
   add_index "memberships", ["member_id"], name: "index_memberships_on_member_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                               default: "",    null: false
-    t.string   "encrypted_password",                  default: "",    null: false
+    t.string   "email",                           default: "",    null: false
+    t.string   "encrypted_password",              default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                       default: 0,     null: false
+    t.integer  "sign_in_count",                   default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -115,14 +115,14 @@ ActiveRecord::Schema.define(version: 20151107030406) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "name"
-    t.boolean  "initialized",                         default: false, null: false
+    t.boolean  "initialized",                     default: false, null: false
     t.text     "tokens"
     t.string   "provider"
     t.string   "uid"
     t.string   "confirmation_token"
     t.integer  "utc_offset"
-    t.boolean  "add_subscribed_to_personal_activity", default: true
-    t.boolean  "subscribed_to_daily_digest",          default: true
+    t.boolean  "subscribed_to_personal_activity", default: true
+    t.boolean  "subscribed_to_daily_digest",      default: true
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151104171710) do
+ActiveRecord::Schema.define(version: 20151105204527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20151104171710) do
     t.string   "provider"
     t.string   "uid"
     t.string   "confirmation_token"
-    t.integer  "utc_offset",             default: 0
+    t.integer  "utc_offset"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151009191350) do
+ActiveRecord::Schema.define(version: 20151104171710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 20151009191350) do
     t.string   "provider"
     t.string   "uid"
     t.string   "confirmation_token"
+    t.integer  "utc_offset",             default: 0
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,38 @@
 require 'faker'
 require 'factory_girl_rails'
 
+### TIMEZONES
+
+utc_offsets = [
+  - 720, # baker island
+  - 660, # hawaii
+  - 600, # cook islands
+  - 540, # alaska (anchorage)
+  - 480, # california
+  - 420, # colorado
+  - 360, # costa rica
+  - 300, # ecuador
+  - 240, # brazil
+  - 180, # uruguay
+  - 120, # south sandwich islands
+  -  60, # cape verde
+  +   0, # ghana
+  +  60, # france
+  + 120, # finland
+  + 180, # ethiopia
+  + 240, # armenia
+  + 300, # pakistan
+  + 360, # bangladesh
+  + 420, # cambodia
+  + 480, # singapore
+  + 540, # japan
+  + 600, # australia, queensland
+  + 660, # new caledonia
+  + 720, # auckland
+  + 780, # samoa
+  + 840  # line islands
+]
+
 ### USERS
 
 Allocation.destroy_all
@@ -11,16 +43,21 @@ Group.destroy_all
 Membership.destroy_all
 User.destroy_all
 
-admin = User.create(name: 'Admin', email: 'admin@example.com', password: 'password')
+admin = User.create(name: 'Admin', email: 'admin@example.com', password: 'password', utc_offset: -480) # oaklander
 puts "generated admin account email: 'admin@example.com', password: 'password'"
-non_admin = User.create(name: 'User', email: 'user@example.com', password: 'password')
+non_admin = User.create(name: 'User', email: 'user@example.com', password: 'password', utc_offset: -480) # oaklander
 puts "generated user account email: 'user@example.com', password: 'password'"
 
 users = []
-18.times do
-  users << User.create!(name: Faker::Name.name, email: Faker::Internet.email, password: 'password')
+utc_offsets.each do |utc_offset|
+  users << User.create!(
+    name: Faker::Name.name, 
+    email: Faker::Internet.email, 
+    password: 'password', 
+    utc_offset: utc_offset
+  )
 end
-puts "generated 18 more fake users"
+puts "generated 27 more fake users"
 
 ### GROUPS
 

--- a/lib/core_ext/action_mailer.rb
+++ b/lib/core_ext/action_mailer.rb
@@ -1,0 +1,9 @@
+module ActionMailer
+  class Base
+    def do_not_deliver
+      def self.deliver
+        false
+      end
+    end
+  end
+end

--- a/lib/tasks/cobudget.rake
+++ b/lib/tasks/cobudget.rake
@@ -1,4 +1,5 @@
 namespace :cobudget do
+  desc "delivers daily email digest to users with recent activity whose local time is between 6AM - 7AM"
   task deliver_daily_email_digest: :environment do
     DeliverDailyEmailDigest.to_subscribers!
   end

--- a/lib/tasks/cobudget.rake
+++ b/lib/tasks/cobudget.rake
@@ -1,0 +1,5 @@
+namespace :cobudget do
+  task deliver_daily_email_digest: :environment do
+    DeliverDailyEmailDigest.to_subscribers!
+  end
+end

--- a/spec/controllers/contributions_controller_spec.rb
+++ b/spec/controllers/contributions_controller_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe ContributionsController, type: :controller do
+  before do
+    make_user_group_member
+    request.headers.merge!(user.create_new_auth_token)
+  end
+
+  describe "#create" do
+    before do
+      bucket.update(target: 100, group: group)
+    end
+
+    context "contribution amount does not exceed contributor's balance" do
+      before do
+        create(:allocation, user: user, group: group, amount: 1000)
+      end
+
+      context "contribution amount does not exceed bucket's funding target" do
+        before do
+          contribution_params = {
+            bucket_id: bucket.id,
+            amount: 50
+          }
+          post :create, {contribution: contribution_params}
+          @contribution = Contribution.find_by(contribution_params)
+        end
+
+        it "returns http status created" do
+          expect(response).to have_http_status(:created)
+        end
+
+        it "creates contribution for current_user with specified amount" do
+          expect(@contribution).to be_truthy
+        end
+
+        it "returns the contribution as json" do
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["contributions"][0]["id"]).to eq(@contribution.id)
+        end
+      end
+
+      context "contribution amount meets bucket's funding target" do
+        it "updates bucket status to 'funded'" do
+          contribution_params = {
+            bucket_id: bucket.id,
+            amount: 100
+          }
+          post :create, {contribution: contribution_params}
+          expect(bucket.reload.status).to eq('funded')  
+        end
+      end
+
+      context "contribution amount exceeds bucket's funding target" do
+        it "contribution amount is decreased to exactly meet the bucket's funding target" do
+          contribution_params = {
+            bucket_id: bucket.id,
+            amount: 150
+          }
+          post :create, {contribution: contribution_params}
+          @contribution = Contribution.find_by(bucket: bucket)
+          expect(@contribution.amount).to eq(100)
+        end
+      end
+    end
+
+    context "contribution amount exceeds contributor's balance" do
+      before do
+        create(:allocation, user: user, amount: 10)
+        contribution_params = {
+          bucket_id: bucket.id,
+          amount: 50
+        }
+        post :create, {contribution: contribution_params}
+        @contribution = Contribution.find_by(contribution_params)
+      end
+
+      it "returns http status forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not create the contribution" do
+        expect(@contribution).to be_nil
+      end
+    end
+  end
+end

--- a/spec/extras/deliver_daily_email_digest_spec.rb
+++ b/spec/extras/deliver_daily_email_digest_spec.rb
@@ -34,7 +34,7 @@ describe "DeliverDailyEmailDigest" do
 
     xcontext "user does not have a utc_offset specified yet" do
       it "does not send any emails" do
-        
+
       end
     end
 

--- a/spec/extras/deliver_daily_email_digest_spec.rb
+++ b/spec/extras/deliver_daily_email_digest_spec.rb
@@ -2,45 +2,89 @@ require 'rails_helper'
 
 describe "DeliverDailyEmailDigest" do
   describe "#to_subscribers!" do
+    before do
+      # at this particular time in the world ..
+      @current_utc_time = DateTime.parse("2015-11-05T05:00:00Z")
+
+      # for the parisians (UTC offset +60 min) it is currently 6AM
+      @parisian_user_1 = create(:user, utc_offset: +60)
+      @parisian_user_2 = create(:user, utc_offset: +60)
+
+      # for the oaklanders (UTC offset -480 min) it is currently 9PM
+      oakland_user_1 = create(:user, utc_offset: -480)
+      oakland_user_2 = create(:user, utc_offset: -480)
+
+      # and for the aucklanders (UTC offset +720 min) it is currently 6PM
+      auckland_user_1 = create(:user, utc_offset: +720)
+      auckland_user_2 = create(:user, utc_offset: +720)
+
+      # all are members of the same group
+      User.all.each { |user| create(:membership, group: group, member: user) }      
+
+      # and just an hour ago, there was some recent activity in the group!
+      Timecop.freeze(@current_utc_time - 1.hour) do
+        create(:draft_bucket, group: group) # a new idea was made
+        create(:live_bucket, group: group) # an idea started its funding phase
+        create(:funded_bucket, group: group) # and a funding bucket became fully funded
+      end
+    end
+
     after do
       ActionMailer::Base.deliveries.clear
       Timecop.return
     end
 
-    it "sends emails to all users whose local time is currently between 6am and 7am" do
-      current_utc_time = "2015-11-05T05:00:00Z"
-      Timecop.freeze(DateTime.parse(current_utc_time))
-      # in paris (UTC offset +60 min) it is currently 6AM
-      # in oakland (UTC offset -480 min) it is currently 9PM
-      # in auckland (UTC offset +720 min) it is currently 6PM
+    it "sends emails to all users with recent activity whose local time is currently between 6am and 7am" do
+      # but when the daily email digest is sent, only the parisians know about it, because it's 6am for them
+      Timecop.freeze(@current_utc_time) do
+        DeliverDailyEmailDigest.to_subscribers!
+        @sent_emails = ActionMailer::Base.deliveries
+        @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
 
-      parisian_user_1 = create(:user, utc_offset: +60)
-      parisian_user_2 = create(:user, utc_offset: +60)
-
-      oakland_user_1 = create(:user, utc_offset: -480)
-      oakland_user_2 = create(:user, utc_offset: -480)
-
-      auckland_user_1 = create(:user, utc_offset: +720)
-      auckland_user_2 = create(:user, utc_offset: +720)
-
-      DeliverDailyEmailDigest.to_subscribers!
-      @sent_emails = ActionMailer::Base.deliveries
-      @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
-
-      expect(@recipient_email_addresses.length).to eq(2)      
-      expect(@recipient_email_addresses).to include(parisian_user_1.email)
-      expect(@recipient_email_addresses).to include(parisian_user_2.email)
-    end
-
-    xcontext "user does not have a utc_offset specified yet" do
-      it "does not send any emails" do
-
+        expect(@recipient_email_addresses.length).to eq(2)      
+        expect(@recipient_email_addresses).to include(@parisian_user_1.email)
+        expect(@recipient_email_addresses).to include(@parisian_user_2.email)
       end
     end
 
-    xcontext "there has been no recent activity" do
+    context "user does not have a utc_offset specified yet" do
       it "does not send any emails" do
+        # but what if one of our parisian users doesn't have a utc_offset associated with their account yet?
+        @parisian_user_1.update(utc_offset: nil)
+        # then, our server has no idea that they're in paris, and that its 6am there.
 
+        # so, when it's 6am in paris
+        Timecop.freeze(@current_utc_time) do
+          # and the digest is sent out
+          DeliverDailyEmailDigest.to_subscribers!
+          @sent_emails = ActionMailer::Base.deliveries
+          @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
+
+          # only 1 email is sent to parisian user 2
+          expect(@recipient_email_addresses.length).to eq(1)    
+          expect(@recipient_email_addresses).not_to include(@parisian_user_1.email)
+          expect(@recipient_email_addresses).to include(@parisian_user_2.email)
+          # because the server has no idea that parisian user 1 is in paris
+        end
+      end
+    end
+
+    context "there has been no recent activity" do
+      it "does not send any emails" do
+        # and what if both parisian users have utc_offsets associated with their accounts,
+        # but there has been no recent activity?
+        group.buckets.destroy_all
+
+        # then, when it's 6am in paris
+        Timecop.freeze(@current_utc_time) do
+          # and the digest is sent out
+          DeliverDailyEmailDigest.to_subscribers!
+          @sent_emails = ActionMailer::Base.deliveries
+          @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
+
+          # no emails are sent, because there's nothing to report on
+          expect(@recipient_email_addresses.length).to eq(0)    
+        end
       end
     end
   end

--- a/spec/extras/deliver_daily_email_digest_spec.rb
+++ b/spec/extras/deliver_daily_email_digest_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "DeliverDailyEmailDigest" do
+  describe "#to_subscribers!" do
+    after do
+      ActionMailer::Base.deliveries.clear
+      Timecop.return
+    end
+
+    it "sends emails to all users whose local time is currently between 6am and 7am" do
+      current_utc_time = "2015-11-05T05:00:00Z"
+      Timecop.freeze(DateTime.parse(current_utc_time))
+      # in paris (UTC offset +60 min) it is currently 6AM
+      # in oakland (UTC offset -480 min) it is currently 9PM
+      # in auckland (UTC offset +720 min) it is currently 6PM
+
+      parisian_user_1 = create(:user, utc_offset: +60)
+      parisian_user_2 = create(:user, utc_offset: +60)
+
+      oakland_user_1 = create(:user, utc_offset: -480)
+      oakland_user_2 = create(:user, utc_offset: -480)
+
+      auckland_user_1 = create(:user, utc_offset: +720)
+      auckland_user_2 = create(:user, utc_offset: +720)
+
+      DeliverDailyEmailDigest.to_subscribers!
+      @sent_emails = ActionMailer::Base.deliveries
+      @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
+
+      expect(@recipient_email_addresses.length).to eq(2)      
+      expect(@recipient_email_addresses).to include(parisian_user_1.email)
+      expect(@recipient_email_addresses).to include(parisian_user_2.email)
+    end
+  end
+end

--- a/spec/extras/deliver_daily_email_digest_spec.rb
+++ b/spec/extras/deliver_daily_email_digest_spec.rb
@@ -31,5 +31,17 @@ describe "DeliverDailyEmailDigest" do
       expect(@recipient_email_addresses).to include(parisian_user_1.email)
       expect(@recipient_email_addresses).to include(parisian_user_2.email)
     end
+
+    xcontext "user does not have a utc_offset specified yet" do
+      it "does not send any emails" do
+        
+      end
+    end
+
+    xcontext "there has been no recent activity" do
+      it "does not send any emails" do
+
+      end
+    end
   end
 end

--- a/spec/extras/deliver_daily_email_digest_spec.rb
+++ b/spec/extras/deliver_daily_email_digest_spec.rb
@@ -79,11 +79,22 @@ describe "DeliverDailyEmailDigest" do
         Timecop.freeze(@current_utc_time) do
           # and the digest is sent out
           DeliverDailyEmailDigest.to_subscribers!
-          @sent_emails = ActionMailer::Base.deliveries
-          @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
+          sent_emails = ActionMailer::Base.deliveries
 
           # no emails are sent, because there's nothing to report on
-          expect(@recipient_email_addresses.length).to eq(0)    
+          expect(sent_emails.length).to eq(0)
+        end
+      end
+    end
+
+    context "users not subscribed to daily digest" do
+      it "does not send daily digest emails" do
+        User.update_all(subscribed_to_daily_digest: false)
+
+        Timecop.freeze(@current_utc_time) do
+          DeliverDailyEmailDigest.to_subscribers!
+          sent_emails = ActionMailer::Base.deliveries
+          expect(sent_emails.length).to eq(0)    
         end
       end
     end

--- a/spec/factories/buckets.rb
+++ b/spec/factories/buckets.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :bucket do
-    name { Faker::Company.name }
+    name { Faker::Lorem.sentence }
     group
     user
     target 500
@@ -8,7 +8,7 @@ FactoryGirl.define do
   end
 
   factory :funded_bucket, class: Bucket do
-    name { Faker::Company.name }
+    name { Faker::Lorem.sentence }
     group
     user
     target 500
@@ -16,7 +16,7 @@ FactoryGirl.define do
   end
 
   factory :live_bucket, class: Bucket do
-    name { Faker::Company.name }
+    name { Faker::Lorem.sentence }
     group
     user
     target 500
@@ -24,7 +24,7 @@ FactoryGirl.define do
   end
 
   factory :draft_bucket, class: Bucket do
-    name { Faker::Company.name }
+    name { Faker::Lorem.sentence }
     group
     user
     status 'draft'

--- a/spec/factories/buckets.rb
+++ b/spec/factories/buckets.rb
@@ -7,6 +7,14 @@ FactoryGirl.define do
     status 'live'
   end
 
+  factory :funded_bucket, class: Bucket do
+    name { Faker::Company.name }
+    group
+    user
+    target 500
+    status 'funded'
+  end
+
   factory :live_bucket, class: Bucket do
     name { Faker::Company.name }
     group

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,7 @@ FactoryGirl.define do
     email { Faker::Internet.email }
     password 'password'
     initialized true
+    subscribed_to_personal_activity true
+    subscribed_to_daily_digest true
   end
 end

--- a/spec/services/bucket_service_spec.rb
+++ b/spec/services/bucket_service_spec.rb
@@ -13,7 +13,7 @@ describe "BucketService" do
 
   describe "#send_bucket_funded_emails" do
     context "bucket author subscribed to personal activity" do
-      it "bucket author receives only 1 'bucket funded' notification email" do
+      it "bucket author receives notification email" do
         @bucket_author.update(subscribed_to_personal_activity: true)
         BucketService.send_bucket_funded_emails(bucket: bucket)
         emails_to_author = ActionMailer::Base.deliveries.select { |e| e.to.first == @bucket_author.email }

--- a/spec/services/bucket_service_spec.rb
+++ b/spec/services/bucket_service_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "BucketService" do
+  before do
+    @bucket_author = bucket.user
+    @contribution = create(:contribution, bucket: bucket, amount: bucket.target)
+    bucket.update(status: 'funded')
+  end
+
+  after do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "#send_bucket_funded_emails" do
+    context "bucket author subscribed to personal activity" do
+      it "bucket author receives only 1 'bucket funded' notification email" do
+        @bucket_author.update(subscribed_to_personal_activity: true)
+        BucketService.send_bucket_funded_emails(bucket: bucket)
+        emails_to_author = ActionMailer::Base.deliveries.select { |e| e.to.first == @bucket_author.email }
+        expect(emails_to_author.length).to eq(1)
+      end
+    end
+
+    context "bucket author not subscribed to personal activity" do
+      it "bucket author does not receive notification email" do
+        @bucket_author.update(subscribed_to_personal_activity: false)
+        BucketService.send_bucket_funded_emails(bucket: bucket)
+        email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
+        expect(email_recipients).not_to include(@bucket_author.email)
+      end
+    end
+  end
+end

--- a/spec/services/comment_service_spec.rb
+++ b/spec/services/comment_service_spec.rb
@@ -1,14 +1,33 @@
-xdescribe "CommentService" do
-  # waiting to hear from derek before writing these tests
+require "rails_helper"
 
+describe "CommentService" do
   describe "#send_new_comment_emails(comment: )" do
-
-    context "bucket's author has been deleted" do
-
+    before do
+      @bucket_author = bucket.user
+      @comment = create(:comment, bucket: bucket)
+      @comment_author = @comment.user
     end
 
-    context "commentor is also author of bucket" do
+    after do 
+      ActionMailer::Base.deliveries.clear
+    end
 
+    context "bucket author subscribed to personal activity" do
+      it "bucket author receives notification email" do
+        @bucket_author.update(subscribed_to_personal_activity: true)
+        CommentService.send_new_comment_emails(comment: @comment)
+        email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
+        expect(email_recipients).to include(@bucket_author.email)
+      end
+    end
+
+    context "bucket author not subscribed to personal activity" do
+      it "bucket author does not receive notification email" do
+        @bucket_author.update(subscribed_to_personal_activity: false)
+        CommentService.send_new_comment_emails(comment: @comment)
+        email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
+        expect(email_recipients).not_to include(@bucket_author.email)
+      end
     end
   end
 end

--- a/spec/services/contribution_service_spec.rb
+++ b/spec/services/contribution_service_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "ContributionService" do
+  before do
+    @bucket_author = bucket.user
+    @contribution = create(:contribution, bucket: bucket)
+    @funder = @contribution.user
+  end
+
+  after do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "send_bucket_received_contribution_emails" do
+    context "bucket author subscribed to personal activity" do
+      it "bucket author receives notification email" do
+        @bucket_author.update(subscribed_to_personal_activity: true)
+        ContributionService.send_bucket_received_contribution_emails(contribution: @contribution)
+        email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
+        expect(email_recipients).to include(@bucket_author.email)
+      end
+    end
+
+    context "bucket author not subscribed to personal activity" do
+      it "bucket author does not receive notification email" do
+        @bucket_author.update(subscribed_to_personal_activity: false)
+        ContributionService.send_bucket_received_contribution_emails(contribution: @contribution)
+        email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
+        expect(email_recipients).not_to include(@bucket_author.email)
+      end
+    end
+  end
+end

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe "UserService" do
+  describe "#set_utc_offset(user:, utc_offset:)" do
+    before do
+      UserService.set_utc_offset(user: user, utc_offset: -480)
+    end
+
+    it "updates the user's utc_offset" do
+      expect(user.utc_offset).to eq(-480)
+    end
+
+    context "user does not have email digest background job scheduled" do
+      it "schedules one" do
+      end
+    end
+  end
+end

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -1,17 +1,76 @@
 require 'rails_helper'
 
 describe "UserService" do
-  describe "#set_utc_offset(user:, utc_offset:)" do
-    before do
-      UserService.set_utc_offset(user: user, utc_offset: -480)
+  describe "#fetch_recent_activity_for" do
+    context "user has one membership" do
+      before do
+        make_user_group_member
+        user.update(utc_offset: -480) # user is in oakland
+        utc_offset_in_hours = user.utc_offset / 60
+        oakland_6am_today_in_utc = (DateTime.now.in_time_zone(utc_offset_in_hours).beginning_of_day + 6.hours).utc
+        oakland_6am_yesterday_in_utc = oakland_6am_today_in_utc - 1.day
+
+        Timecop.freeze(oakland_6am_yesterday_in_utc - 1.hours) do
+          create(:draft_bucket, group: group)
+          create(:live_bucket, group: group)
+          create(:funded_bucket, group: group)
+        end
+
+        Timecop.freeze(oakland_6am_yesterday_in_utc + 2.hours) do
+          @d1 = create(:draft_bucket, group: group)
+          @l1 = create(:live_bucket, group: group)
+          @f1 = create(:funded_bucket, group: group)
+        end
+
+        Timecop.freeze(oakland_6am_yesterday_in_utc + 3.hours) do
+          @d2 = create(:draft_bucket, group: group)
+          @l2 = create(:live_bucket, group: group)
+          @f2 = create(:funded_bucket, group: group)
+        end
+
+        Timecop.freeze(oakland_6am_today_in_utc + 1.hours) do
+          create(:draft_bucket, group: group)
+          create(:live_bucket, group: group)
+          create(:funded_bucket, group: group)
+        end
+
+        @recent_activity = UserService.fetch_recent_activity_for(user: user)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "returns users group" do
+        expect(@recent_activity[0][:group]).to eq(group)
+      end
+
+      it "returns all draft buckets created between 6am yesterday and 6am today (user's local time)" do
+        expect(@recent_activity[0][:draft_buckets].length).to eq(2)
+        expect(@recent_activity[0][:draft_buckets]).to include(@d1, @d2) 
+      end 
+
+      it "returns all buckets that became live between 6am yesterday and 6am today (user's local time)" do
+        expect(@recent_activity[0][:live_buckets].length).to eq(2)
+        expect(@recent_activity[0][:live_buckets]).to include(@l1, @l2) 
+      end
+
+      it "returns all buckets that became funded between 6am yesterday and 6am today (user's local time)" do
+        expect(@recent_activity[0][:funded_buckets].length).to eq(2)
+        expect(@recent_activity[0][:funded_buckets]).to include(@f1, @f2) 
+      end
     end
 
-    it "updates the user's utc_offset" do
-      expect(user.utc_offset).to eq(-480)
-    end
+    context "user has multiple memberships" do
+      before do
+        make_user_group_member
+        create(:membership, member: user)
+        create(:membership, member: user)
+        @recent_activity = UserService.fetch_recent_activity_for(user: user)
+      end
 
-    context "user does not have email digest background job scheduled" do
-      it "schedules one" do
+      it "returns recent activity for every group user is a member of" do
+        expect(@recent_activity.length).to eq(3)
       end
     end
   end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -16,7 +16,7 @@ module MyLetDeclarations
   # HTTP status codes
   let(:success) { 200 }
   let(:created) { 201 }
-  let(:updated) { 204 }
+  let(:unauthorized) { 401 }
   let(:forbidden) { 403 }
   let(:conflict) { 409 }
   let(:unprocessable) { 422 }


### PR DESCRIPTION
in this pull request, a job was created (intended to run hourly) which sends a digest to all subscribing user's whose local time is currently between 6AM - 7AM (their local time). the digest contains recent activity, recent meaning occurring between 6AM yesterday and 6AM today (user's local time). users are automatically subscribed to this digest

if there has been no recent activity for a group member, then no email digest is sent. i figure, if there's nothing to report, why send a report?

also, if the user does not have a `utc_offset` associated with their account, then no email digest is sent. i figure, recent activity means 'recent activity for the user'. and the server has no way to know what that means unless the user has a `utc_offset` associated with their account. 

this means that current users of beta will not receive the email digest until they have logged in via the login form. this is when the user's `utc_offset` is updated. so, some current users of beta will have to log out and then log back in before the email digest starts doing its thing.

also in this pull request, majority of email notifications were temporarily removed, except allocation, invite, reset password, and "activity on my bucket" notifications.

---

have also added a small bug-fix -- user cannot create a contribution unless they have sufficient funds for it (should've been fixed a looong time ago lol).

