### PR TITLE
Feature/remove user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'redcarpet'
 group :development do
   gem 'capistrano', '2.15.5'
   gem "capistrano-rails", '~> 1.0.0'
+  gem "rails-erd"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       net-ssh-gateway (>= 1.1.0)
     capistrano-rails (1.0.0)
       capistrano
+    choice (0.2.0)
     coderay (1.1.0)
     columnize (0.9.0)
     daemons (1.2.2)
@@ -168,6 +169,11 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
+    rails-erd (1.4.4)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
     rails_12factor (0.0.3)
@@ -201,6 +207,7 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    ruby-graphviz (1.2.2)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -256,6 +263,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 4.2.3)
   rails-api
+  rails-erd
   rails_12factor
   redcarpet
   responders (~> 2.0)

--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -15,7 +15,7 @@ class BucketsController < AuthenticatedController
   def create
     bucket = Bucket.new(bucket_params_create)
     if bucket.save
-      # BucketService.send_bucket_created_emails(bucket: bucket, current_user: current_user)
+      # BucketService.send_bucket_created_emails(bucket: bucket)
       render json: [bucket]
     else 
       render json: {

--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -45,7 +45,7 @@ class BucketsController < AuthenticatedController
   def open_for_funding
     bucket = Bucket.find(params[:id])
     bucket.open_for_funding(target: params[:target], funding_closes_at: params[:funding_closes_at])
-    # BucketService.send_bucket_live_emails(bucket: bucket, current_user: current_user)
+    # BucketService.send_bucket_live_emails(bucket: bucket)
     render json: [bucket]
   end
 

--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -1,5 +1,5 @@
 class BucketsController < AuthenticatedController
-  api :GET, '/buckets?group_id='
+  api :GET, '/buckets?group_id'
   def index 
     group = Group.find(params[:group_id])
     render json: group.buckets
@@ -42,6 +42,7 @@ class BucketsController < AuthenticatedController
     destroy_resource
   end
 
+  api :POST '/buckets/:id?target&funding_closes_at'
   def open_for_funding
     bucket = Bucket.find(params[:id])
     bucket.open_for_funding(target: params[:target], funding_closes_at: params[:funding_closes_at])

--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -42,7 +42,7 @@ class BucketsController < AuthenticatedController
     destroy_resource
   end
 
-  api :POST '/buckets/:id?target&funding_closes_at'
+  api :POST, '/buckets/:id?target&funding_closes_at'
   def open_for_funding
     bucket = Bucket.find(params[:id])
     bucket.open_for_funding(target: params[:target], funding_closes_at: params[:funding_closes_at])

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,6 +10,7 @@ class GroupsController < AuthenticatedController
   api :POST, '/groups', 'Create a group'
   def create
     group = Group.create(group_params)
+    group.update(initialized: true)
     group.add_admin(current_user)
     render json: [group]
   end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -16,12 +16,12 @@ class MembershipsController < AuthenticatedController
     render json: [membership]
   end
 
-  def destroy
+  def archive
     membership = Membership.find(params[:id])
-    if current_user.is_admin_for?(membership.group)
-      MembershipService.delete_membership(membership: membership)
+    if current_user.is_admin_for?(membership.group)    
+      membership.update(archived_at: DateTime.now.utc)
       render nothing: true, status: 200
-    else
+    else 
       render nothing: true, status: 403
     end
   end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -23,7 +23,7 @@ class MembershipsController < AuthenticatedController
   def archive
     membership = Membership.find(params[:id])
     if current_user.is_admin_for?(membership.group)    
-      membership.update(archived_at: DateTime.now.utc)
+      MembershipService.archive_membership(membership: membership)
       render nothing: true, status: 200
     else 
       render nothing: true, status: 403

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,5 +1,5 @@
 class MembershipsController < AuthenticatedController
-  api :GET, 'memberships?group_id=', 'Get memberships for a particular group'
+  api :GET, 'memberships?group_id', 'Get memberships for a particular group'
   def index
     group = Group.find(params[:group_id])
     render json: group.memberships.active

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -2,12 +2,12 @@ class MembershipsController < AuthenticatedController
   api :GET, 'memberships?group_id=', 'Get memberships for a particular group'
   def index
     group = Group.find(params[:group_id])
-    render json: group.memberships
+    render json: group.memberships.active
   end
 
   api :GET, 'memberships/my_memberships', 'Get memberships for the current_user'
   def my_memberships
-    render json: Membership.where(member_id: current_user.id)
+    render json: Membership.where(member_id: current_user.id).active
   end
 
   def update

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -2,7 +2,11 @@ class MembershipsController < AuthenticatedController
   api :GET, 'memberships?group_id', 'Get memberships for a particular group'
   def index
     group = Group.find(params[:group_id])
-    render json: group.memberships.active
+    if current_user.is_member_of?(group)
+      render json: group.memberships.active, status: 200
+    else
+      render nothing: true, status: 403
+    end
   end
 
   api :GET, 'memberships/my_memberships', 'Get memberships for the current_user'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,16 +12,17 @@ class UsersController < AuthenticatedController
     end
   end
 
-  api :POST, '/users?invite_group'
-  def create
-    # TODO: only an admin should be able to create a user
-    user = User.create_with_confirmation_token(email: user_params[:email])
+  api :POST, '/users/invite_to_create_group?email'
+  def invite_to_create_group
+    user = User.create_with_confirmation_token(email: params[:email])
     if user.valid?
-      UserMailer.invite_new_group_email(user: user, inviter: current_user).deliver_later
+      group = Group.create(name: "New Group")
+      group.add_admin(user)
+      UserMailer.invite_new_group_email(user: user, inviter: current_user, group: group).deliver_later
       render nothing: true
     else
       render status: 409, nothing: true
-    end
+    end    
   end
 
   api :POST, '/users/update_profile'
@@ -59,6 +60,6 @@ class UsersController < AuthenticatedController
 
   private
     def user_params
-      params.require(:user).permit(:email, :utc_offset)
+      params.require(:user).permit(:utc_offset)
     end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -112,10 +112,10 @@ class UserMailer < ActionMailer::Base
          subject: "#{admin.name} gave you funds to spend in #{@group.name}")
   end
 
-  def invite_new_group_email(user: , inviter:)
+  def invite_new_group_email(user: , inviter:, group:)
     @user = user
     @inviter = inviter
-    @redirect_url = "#{root_url}#/confirm_account?confirmation_token=#{@user.confirmation_token}&create_group=true".html_safe
+    @redirect_url = "#{root_url}#/confirm_account?confirmation_token=#{@user.confirmation_token}&group_id=#{group.id}".html_safe
     mail(to: @user.name_and_email,
          from: "Cobudget Accounts <accounts@cobudget.co>",
          subject: "#{inviter.name} invited you to create a new group on Cobudget")

--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -5,6 +5,7 @@ class Bucket < ActiveRecord::Base
   belongs_to :user
 
   validates :name, presence: true
+  validates :description, presence: true
   validates :group_id, presence: true
   validates :user_id, presence: true
   validates :status, presence: true

--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -1,5 +1,5 @@
 class Bucket < ActiveRecord::Base
-  has_many :contributions, -> { order("amount DESC") }
+  has_many :contributions, -> { order("amount DESC") }, dependent: :destroy
   has_many :comments, dependent: :destroy
   belongs_to :group
   belongs_to :user
@@ -50,6 +50,25 @@ class Bucket < ActiveRecord::Base
     renderer = Redcarpet::Render::HTML.new 
     markdown = Redcarpet::Markdown.new(renderer, extensions = {})
     markdown.render(description).html_safe
+  end
+
+  def participants(exclude_author: nil, type: nil, subscribed: nil)
+    case type
+      when :contributors then ids = contributions.pluck(:user_id)
+      when :comments then ids = comments.pluck(:user_id)
+      else ids = (contributions.pluck(:user_id) + comments.pluck(:user_id)).uniq
+    end
+    users = User.where(id: ids)
+    users = users.where.not(id: user_id) if exclude_author
+    users.all
+  end
+
+  def contributors(exclude_author: nil)
+    participants(exclude_author: exclude_author, type: :contributors)
+  end
+
+  def commenters(exclude_author: nil)
+    participants(exclude_author: exclude_author, type: :commenters)
   end
 
   private

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -6,7 +6,7 @@ class Membership < ActiveRecord::Base
   validates :member_id, presence: true, uniqueness: { scope: :group_id }
 
   scope :archived, -> { where.not(archived_at: nil) }
-  scope :live, -> { where(archived_at: nil) }
+  scope :active, -> { where(archived_at: nil) }
 
   def total_allocations
     group.allocations.where(user_id: member_id).sum(:amount)

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -5,6 +5,9 @@ class Membership < ActiveRecord::Base
   validates :group_id, presence: true
   validates :member_id, presence: true, uniqueness: { scope: :group_id }
 
+  scope :archived, -> { where.not(archived_at: nil) }
+  scope :live, -> { where(archived_at: nil) }
+
   def total_allocations
     group.allocations.where(user_id: member_id).sum(:amount)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,11 +10,12 @@ class User < ActiveRecord::Base
   ### from previous authentication scheme ###
   # include TokenAuthenticable
 
-  has_many :allocations
-  has_many :memberships, foreign_key: "member_id"
   has_many :groups, through: :memberships
-  has_many :comments
-  has_many :contributions
+  has_many :memberships, foreign_key: "member_id", dependent: :destroy
+  has_many :allocations, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :contributions, dependent: :destroy
+  has_many :buckets, dependent: :destroy
 
   validates :name, presence: true
   validates_format_of :email, :with => /\A[^@]+@([^@\.]+\.)+[^@\.]+\z/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,11 +33,11 @@ class User < ActiveRecord::Base
   end
 
   def is_admin_for?(group)
-    Membership.where(group: group, member: self, is_admin: true).length > 0
+    Membership.where(group: group, member: self, archived_at: nil, is_admin: true).length > 0
   end
 
   def is_member_of?(group)
-    group.members.include?(self)
+    Membership.where(group: group, member: self, archived_at: nil).length > 0
   end
 
   def has_set_up_account?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,10 +44,6 @@ class User < ActiveRecord::Base
     confirmation_token.nil?
   end
 
-  def archive!
-    update(archived_at: DateTime.now.utc)
-  end
-
   private
     def assign_uid_and_provider
       self.uid = self.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,10 @@ class User < ActiveRecord::Base
     confirmation_token.nil?
   end
 
+  def archive!
+    update(archived_at: DateTime.now.utc)
+  end
+
   private
     def assign_uid_and_provider
       self.uid = self.email

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -4,5 +4,6 @@ class GroupSerializer < ActiveModel::Serializer
              :name,
              :balance,
              :currency_symbol,
-             :currency_code
+             :currency_code,
+             :initialized
 end

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -5,6 +5,7 @@ class MembershipSerializer < ActiveModel::Serializer
              :created_at, 
              :total_allocations, 
              :total_contributions
+             :archived_at
 
   has_one :member, serializer: UserSerializer, root: 'users'
   has_one :group, serializer: GroupSerializer, root: 'groups'

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
   embed :ids, include: true
-  attributes :id, :name, :email, :utc_offset
+  attributes :id, :name, :email, :utc_offset, :archived_at
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
   embed :ids, include: true
-  attributes :id, :name, :email, :utc_offset, :archived_at
+  attributes :id, :name, :email, :utc_offset
 end

--- a/app/services/bucket_service.rb
+++ b/app/services/bucket_service.rb
@@ -1,7 +1,8 @@
 class BucketService
-  def self.send_bucket_created_emails(bucket: , current_user:)
-    members = bucket.group.members.where.not(id: current_user.id)
-    members.each do |member|
+  def self.send_bucket_created_emails(bucket: )
+    memberships = bucket.group.memberships.active.where.not(member_id: bucket.user_id)
+    memberships.each do |membership|
+      member = membership.member
       UserMailer.notify_member_that_bucket_was_created(bucket: bucket, member: member).deliver_later
     end
   end

--- a/app/services/bucket_service.rb
+++ b/app/services/bucket_service.rb
@@ -24,6 +24,8 @@ class BucketService
     if bucket_author && bucket_author.subscribed_to_personal_activity
       UserMailer.notify_author_that_bucket_is_funded(bucket: bucket).deliver_later
     end
+
+    ## TODO, when this is brought back, need to add .active filter to memberships
     # members = bucket.group.members.reject { |member| member == bucket_author }
     # members.each do |member|
     #   UserMailer.notify_member_that_bucket_is_funded(bucket: bucket, member: member).deliver_later

--- a/app/services/bucket_service.rb
+++ b/app/services/bucket_service.rb
@@ -7,8 +7,8 @@ class BucketService
     end
   end
 
-  def self.send_bucket_live_emails(bucket: , current_user: )
-    memberships = bucket.group.memberships.reject { |membership| membership.member == current_user }
+  def self.send_bucket_live_emails(bucket: )
+    memberships = bucket.group.memberships.active.reject { |membership| membership.member == bucket.user }
     memberships.each do |membership|
       member = membership.member
       if membership.balance > 0

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -4,8 +4,8 @@ class CommentService
     bucket_author = bucket.user
     comment_author = comment.user
 
-    # in case bucket_author was deleted
-    if bucket_author && bucket_author != comment_author && bucket_author.subscribed_to_personal_activity
+    
+    if bucket_author.is_member_of?(bucket.group) && bucket_author != comment_author && bucket_author.subscribed_to_personal_activity
       UserMailer.notify_author_of_new_comment_email(comment: comment).deliver_later
     end
 

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -13,6 +13,7 @@ class CommentService
 
     funders =  User.joins(:contributions).where(contributions: {bucket_id: bucket.id}).uniq
 
+    # TODO: need to add .active filter to memberships here later
     # users_to_notify = (commenters + funders).uniq.reject { |member| member == comment_author || member == bucket_author }
     # users_to_notify.each { |user| UserMailer.notify_user_of_new_comment_email(comment: comment, user: user).deliver_later } 
   end

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -23,10 +23,7 @@ class MembershipService
     # remove member's funds from group (by creating a negative allocation equal to the member's balance)
     Allocation.create(user: member, group: group, amount: -membership.balance)
 
-    # destroy membership
-    membership.destroy
-
-    # destroy member, if they have no more memberships
-    member.destroy if member.memberships.length == 0
+    # archive membership
+    membership.update(archived_at: DateTime.now.utc)
   end
 end

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -11,7 +11,7 @@ class MembershipService
       contributions = bucket.contributions
       funders = contributions.map { |c| c.user }.uniq
       funders.each do |funder|
-        UserMailer.notify_funder_that_bucket_was_deleted(funder: funder, bucket: bucket).deliver_later
+        UserMailer.notify_funder_that_bucket_was_deleted(funder: funder, bucket: bucket).deliver_now
       end
       contributions.destroy_all
       bucket.destroy

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -8,12 +8,10 @@ class MembershipService
 
     # destroy member's funding buckets, refund all their funders, and notify funders of refund via email
     Bucket.where(user_id: member.id, status: 'live', group_id: group.id).each do |bucket|
-      contributions = bucket.contributions
-      funders = contributions.map { |c| c.user }.uniq
+      funders = bucket.contributors(exclude_author: true)
       funders.each do |funder|
         UserMailer.notify_funder_that_bucket_was_deleted(funder: funder, bucket: bucket).deliver_now
       end
-      contributions.destroy_all
       bucket.destroy
     end
 

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -25,5 +25,9 @@ class MembershipService
 
     # archive membership
     membership.update(archived_at: DateTime.now.utc)
+
+    # archive user if they have no more active memberships
+    member.reload
+    member.archive! if member.memberships.active.length == 0
   end
 end

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -1,5 +1,5 @@
 class MembershipService
-  def self.delete_membership(membership: )
+  def self.archive_membership(membership: )
     member = membership.member
     group = membership.group
 

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -25,9 +25,5 @@ class MembershipService
 
     # archive membership
     membership.update(archived_at: DateTime.now.utc)
-
-    # archive user if they have no more active memberships
-    member.reload
-    member.archive! if member.memberships.active.length == 0
   end
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -5,7 +5,7 @@ class UserService
     user_6am_today_in_utc = (DateTime.now.in_time_zone(user_utc_offset_in_hours).beginning_of_day + 6.hours).utc 
     user_6am_yesterday_in_utc = user_6am_today_in_utc - 1.day
 
-    recent_activity = user.memberships.map do |membership|
+    recent_activity = user.memberships.active.map do |membership|
       group = membership.group
       draft_buckets = Bucket.where(group: group, status: 'draft', created_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))
       live_buckets = Bucket.where(group: group, status: 'live', live_at: (user_6am_yesterday_in_utc ... user_6am_today_in_utc ))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,9 +23,13 @@ Rails.application.routes.draw do
 
     resources :comments, only: [:index, :create]
 
-    resources :memberships, only: [:index, :update, :destroy] do
+    resources :memberships, only: [:index, :update] do
       collection do
         get :my_memberships
+      end
+
+      member do
+        post :archive
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
         post :request_password_reset
         post :reset_password
         post :update_profile
+        post :invite_to_create_group
       end
     end
 

--- a/db/migrate/20151113081236_add_archived_at_to_memberships.rb
+++ b/db/migrate/20151113081236_add_archived_at_to_memberships.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToMemberships < ActiveRecord::Migration
+  def change
+    add_column :memberships, :archived_at, :datetime
+  end
+end

--- a/db/migrate/20151114074950_add_archived_at_to_users.rb
+++ b/db/migrate/20151114074950_add_archived_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :archived_at, :datetime
+  end
+end

--- a/db/migrate/20151114074950_add_archived_at_to_users.rb
+++ b/db/migrate/20151114074950_add_archived_at_to_users.rb
@@ -1,5 +1,0 @@
-class AddArchivedAtToUsers < ActiveRecord::Migration
-  def change
-    add_column :users, :archived_at, :datetime
-  end
-end

--- a/db/migrate/20151114110756_add_initialized_to_groups.rb
+++ b/db/migrate/20151114110756_add_initialized_to_groups.rb
@@ -1,0 +1,10 @@
+class AddInitializedToGroups < ActiveRecord::Migration
+  def up
+    add_column :groups, :initialized, :boolean, default: false
+    Group.update_all(initialized: true)
+  end
+
+  def down
+    remove_column :groups, :initialized
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151107030406) do
+ActiveRecord::Schema.define(version: 20151113081236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,11 +91,12 @@ ActiveRecord::Schema.define(version: 20151107030406) do
   end
 
   create_table "memberships", force: :cascade do |t|
-    t.integer  "group_id",                   null: false
-    t.integer  "member_id",                  null: false
-    t.boolean  "is_admin",   default: false, null: false
+    t.integer  "group_id",                    null: false
+    t.integer  "member_id",                   null: false
+    t.boolean  "is_admin",    default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "archived_at"
   end
 
   add_index "memberships", ["group_id"], name: "index_memberships_on_group_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151113081236) do
+ActiveRecord::Schema.define(version: 20151114074950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 20151113081236) do
     t.integer  "utc_offset"
     t.boolean  "subscribed_to_personal_activity", default: true
     t.boolean  "subscribed_to_daily_digest",      default: true
+    t.datetime "archived_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151114074950) do
+ActiveRecord::Schema.define(version: 20151113081236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,7 +124,6 @@ ActiveRecord::Schema.define(version: 20151114074950) do
     t.integer  "utc_offset"
     t.boolean  "subscribed_to_personal_activity", default: true
     t.boolean  "subscribed_to_daily_digest",      default: true
-    t.datetime "archived_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151113081236) do
+ActiveRecord::Schema.define(version: 20151114110756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20151113081236) do
     t.datetime "updated_at"
     t.string   "currency_symbol", default: "$"
     t.string   "currency_code",   default: "USD"
+    t.boolean  "initialized",     default: false
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -124,6 +125,7 @@ ActiveRecord::Schema.define(version: 20151113081236) do
     t.integer  "utc_offset"
     t.boolean  "subscribed_to_personal_activity", default: true
     t.boolean  "subscribed_to_daily_digest",      default: true
+    t.datetime "archived_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,7 +63,7 @@ puts "generated 27 more fake users"
 
 groups = []
 2.times do
-  group = Group.create!(name: Faker::Company.name)
+  group = Group.create!(name: Faker::Company.name, initialized: true)
   group.add_admin(admin)
   group.add_member(non_admin)
   groups << group

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -52,6 +52,10 @@ describe GroupsController, :type => :controller do
       expect(Membership.find_by(group: @new_group, member: user, is_admin: true)).to be_truthy
     end
 
+    it "initializes group" do
+      expect(@new_group.initialized).to be_truthy
+    end
+
     it "returns new group, as json" do
       expect(@parsed_response["groups"][0]["id"]).to eq(@new_group.id)
     end

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -17,7 +17,7 @@ describe MembershipsController, :type => :controller do
 
       it "returns http status ok" do
         expect(response).to have_http_status(:ok)
-      end
+      end 
 
       it "sets user's archived_at to current time" do
         expect(@membership.archived_at).to be_truthy

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1,11 +1,41 @@
 require 'rails_helper'
 
 describe MembershipsController, :type => :controller do
+  def parsed(response)
+    JSON.parse(response.body)
+  end
+
+  describe "#index" do
+    context "user logged in" do
+      before do
+        make_user_group_member
+        request.headers.merge!(user.create_new_auth_token)
+        create_list(:membership, 5, group: group)
+        create_list(:membership, 2, group: group, archived_at: DateTime.now.utc - 5.days)
+        get :index, group_id: group.id
+      end
+
+      it "returns http status success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns all active memberships for the group" do
+        expect(parsed(response)["memberships"].length).to eq(6)
+      end
+    end
+
+    context "user not logged in" do
+      it "returns http status unauthorized" do
+        get :index, group_id: group.id
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe "#archive" do
     before do
-      make_user_group_member
+      @membership = make_user_group_member
       request.headers.merge!(user.create_new_auth_token)
-      @membership = create(:membership, group: group)
     end
 
     context "group admin" do

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -6,7 +6,7 @@ describe MembershipsController, :type => :controller do
   end
 
   describe "#index" do
-    context "user logged in" do
+    context "user member of group" do
       before do
         make_user_group_member
         request.headers.merge!(user.create_new_auth_token)
@@ -21,6 +21,14 @@ describe MembershipsController, :type => :controller do
 
       it "returns all active memberships for the group" do
         expect(parsed(response)["memberships"].length).to eq(6)
+      end
+    end
+
+    context "user not member of group" do
+      it "returns http status forbidden" do
+        request.headers.merge!(user.create_new_auth_token)
+        get :index, group_id: group.id
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe MembershipsController, :type => :controller do
-  describe "#destroy" do
+  describe "#archive" do
     before do
       make_user_group_member
       request.headers.merge!(user.create_new_auth_token)
@@ -11,17 +11,22 @@ describe MembershipsController, :type => :controller do
     context "group admin" do
       before do
         group.add_admin(user)
+        post :archive, {id: @membership.id}
+        @membership.reload
       end
 
       it "returns http status ok" do
-        delete :destroy, {id: @membership.id}
         expect(response).to have_http_status(:ok)
+      end
+
+      it "sets user's archived_at to current time" do
+        expect(@membership.archived_at).to be_truthy
       end
     end
 
     context "not group admin" do
       it "returns http status forbidden" do
-        delete :destroy, {id: @membership.id}
+        post :archive, {id: @membership.id}
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -40,6 +40,33 @@ describe MembershipsController, :type => :controller do
     end
   end
 
+  describe "#my_memberships" do
+    context "user logged in" do
+      before do
+        create_list(:membership, 3, member: user)
+        create_list(:membership, 8)
+        create_list(:membership, 1, member: user, archived_at: DateTime.now.utc - 5.days)
+        request.headers.merge!(user.create_new_auth_token)
+        get :my_memberships        
+      end
+
+      it "returns http status success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns all users active memberships" do
+        expect(parsed(response)["memberships"].length).to eq(3)
+      end
+    end
+
+    context "user not logged in" do
+      it "returns http status unauthorized" do
+        get :my_memberships
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe "#archive" do
     before do
       @membership = make_user_group_member

--- a/spec/factories/buckets.rb
+++ b/spec/factories/buckets.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :bucket do
     name { Faker::Lorem.sentence }
+    description { Faker::Lorem.paragraph }
     group
     user
     target 500
@@ -9,6 +10,7 @@ FactoryGirl.define do
 
   factory :funded_bucket, class: Bucket do
     name { Faker::Lorem.sentence }
+    description { Faker::Lorem.paragraph }
     group
     user
     target 500
@@ -17,6 +19,7 @@ FactoryGirl.define do
 
   factory :live_bucket, class: Bucket do
     name { Faker::Lorem.sentence }
+    description { Faker::Lorem.paragraph }
     group
     user
     target 500
@@ -25,6 +28,7 @@ FactoryGirl.define do
 
   factory :draft_bucket, class: Bucket do
     name { Faker::Lorem.sentence }
+    description { Faker::Lorem.paragraph }
     group
     user
     status 'draft'

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :group do
     name { Faker::Company.name }
+    initialized { true }
   end
 end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -3,4 +3,10 @@ FactoryGirl.define do
     group
     association :member, factory: :user
   end
+
+  factory :archived_membership, class: Membership do
+    group
+    association :member, factory: :user
+    archived_at { DateTime.now.utc - 5.days }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,30 +5,82 @@ RSpec.describe User, :type => :model do
   let(:membership) { create(:membership, member: user) }
   let(:admin_membership) { create(:membership, member: user, is_admin: true) }
 
-	describe "#name_and_email" do
-		it "returns formatted name and email, formatted for email" do
-			expect(user.name_and_email).to eq("#{user.name} <#{user.email}>")
-		end
-	end
+  describe "#name_and_email" do
+    it "returns formatted name and email, formatted for email" do
+      expect(user.name_and_email).to eq("#{user.name} <#{user.email}>")
+    end
+  end
 
-	describe "#is_admin_for?(group)" do
-		it "returns false if user isn't admin of group" do
-		  expect(user.is_admin_for?(membership.group)).to eq false
-		end
-		
-		it "returns true if user is admin of group" do
-		  expect(user.is_admin_for?(admin_membership.group)).to eq true
-		end
-	end
+  describe "#is_admin_for?(group)" do
+    it "returns false if user isn't admin of group" do
+      expect(user.is_admin_for?(membership.group)).to eq false
+    end
+    
+    it "returns true if user is admin of group" do
+      expect(user.is_admin_for?(admin_membership.group)).to eq true
+    end
+  end
 
-	describe "#is_member_of?(group)" do
-		it "returns false if user isn't a member of group" do
-			make_user_group_member
-			expect(user.is_member_of?(group)).to eq(true)
-		end
+  describe "#is_member_of?(group)" do
+    it "returns false if user isn't a member of group" do
+      make_user_group_member
+      expect(user.is_member_of?(group)).to eq(true)
+    end
 
-		it "returns true if user is a member of the group" do
-			expect(user.is_member_of?(group)).to eq(false)
-		end
-	end
+    it "returns true if user is a member of the group" do
+      expect(user.is_member_of?(group)).to eq(false)
+    end
+  end
+
+  describe "#destroy" do
+    before do
+      @membership1 = create(:membership, member: user)
+      @membership2 = create(:membership, member: user)
+
+      @group1 = @membership1.group
+      @group2 = @membership2.group
+
+      @allocation1 = create(:allocation, user: user, group: @group1, amount: 420)
+      @allocation2 = create(:allocation, user: user, group: @group2, amount: 420)
+
+      @bucket1 = create(:bucket, group: @group1, user: user)
+      @bucket2 = create(:bucket, group: @group2, user: user)
+
+      @other_bucket1 = create(:bucket, group: @group1)
+      @other_bucket2 = create(:bucket, group: @group2)
+
+      @contribution1 = create(:contribution, user: user, bucket: @other_bucket1, amount: 200)
+      @contribution2 = create(:contribution, user: user, bucket: @other_bucket2, amount: 200)
+
+      @comment1 = create(:comment, user: user, bucket: @other_bucket1)
+      @comment2 = create(:comment, user: user, bucket: @other_bucket2)
+
+      user.destroy
+    end
+
+    it "destroys all user's memberships" do
+      expect { @membership1.reload }.to raise_error
+      expect { @membership2.reload }.to raise_error
+    end
+
+    it "destroys all user's allocations" do
+      expect { @allocation1.reload }.to raise_error
+      expect { @allocation2.reload }.to raise_error
+    end
+
+    it "destroys all user's buckets" do
+      expect { @bucket1.reload }.to raise_error
+      expect { @bucket2.reload }.to raise_error
+    end
+
+    it "destroys all user's contributions" do
+      expect { @contribution1.reload }.to raise_error
+      expect { @contribution2.reload }.to raise_error
+    end
+
+    it "destroys all user's comments" do
+      expect { @comment1.reload }.to raise_error
+      expect { @comment2.reload }.to raise_error
+    end
+  end
 end

--- a/spec/services/bucket_service_spec.rb
+++ b/spec/services/bucket_service_spec.rb
@@ -5,7 +5,7 @@ describe "BucketService" do
     ActionMailer::Base.deliveries.clear
   end
 
-  describe "#send_bucket_funded_emails" do
+  describe "#send_bucket_funded_emails(bucket:)" do
     before do
       @bucket_author = bucket.user
       @contribution = create(:contribution, bucket: bucket, amount: bucket.target)
@@ -31,7 +31,7 @@ describe "BucketService" do
     end
   end
 
-  describe "#send_bucket_created_emails" do
+  describe "#send_bucket_created_emails(bucket:)" do
     it "sends emails to all active group members, except creator" do
       make_user_group_member
       bucket = create(:draft_bucket, user: user, group: group)
@@ -40,7 +40,42 @@ describe "BucketService" do
       BucketService.send_bucket_created_emails(bucket: bucket)
       email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
       expect(email_recipients.length).to eq(5)
-      expect(email_recipients).not_to include(user.email)      
+      expect(email_recipients).not_to include(user.email)
+    end
+  end
+
+  describe "#send_bucket_live_emails(bucket:)" do
+    before do
+      make_user_group_member
+      bucket = create(:live_bucket, user: user, group: group)
+
+      allocation = create(:allocation, group: group, amount: 100)
+      @member_with_balance = allocation.user
+      @membership_with_balance = create(:membership, member: @member_with_balance, group: group)
+
+      @membership_without_balance = create(:membership, group: group)
+      @member_without_balance = @membership_without_balance.member
+
+      create_list(:archived_membership, 2, group: group)
+
+      BucketService.send_bucket_live_emails(bucket: bucket)
+      @emails = ActionMailer::Base.deliveries
+      @email_recipients = @emails.map { |e| e.to.first }
+    end
+
+    it "sends emails to all active group members, except creator" do
+      expect(@emails.length).to eq(2)
+      expect(@email_recipients).not_to include(user.email)
+    end
+
+    it "members with funds get an email with their balance" do
+      email = @emails.find { |e| e.to.first ==  @member_with_balance.email }
+      expect(email.body).to include(@membership_with_balance.formatted_balance)
+    end
+
+    it "members without funds get an email that does not contain their balance" do
+      email = @emails.find { |e| e.to.first ==  @member_without_balance.email }
+      expect(email.body).not_to include(@membership_without_balance.formatted_balance)
     end
   end
 end

--- a/spec/services/bucket_service_spec.rb
+++ b/spec/services/bucket_service_spec.rb
@@ -1,17 +1,17 @@
 require "rails_helper"
 
 describe "BucketService" do
-  before do
-    @bucket_author = bucket.user
-    @contribution = create(:contribution, bucket: bucket, amount: bucket.target)
-    bucket.update(status: 'funded')
-  end
-
   after do
     ActionMailer::Base.deliveries.clear
   end
 
   describe "#send_bucket_funded_emails" do
+    before do
+      @bucket_author = bucket.user
+      @contribution = create(:contribution, bucket: bucket, amount: bucket.target)
+      bucket.update(status: 'funded')
+    end
+
     context "bucket author subscribed to personal activity" do
       it "bucket author receives notification email" do
         @bucket_author.update(subscribed_to_personal_activity: true)
@@ -28,6 +28,19 @@ describe "BucketService" do
         email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
         expect(email_recipients).not_to include(@bucket_author.email)
       end
+    end
+  end
+
+  describe "#send_bucket_created_emails" do
+    it "sends emails to all active group members, except creator" do
+      make_user_group_member
+      bucket = create(:draft_bucket, user: user, group: group)
+      create_list(:membership, 5, group: group)
+      create_list(:archived_membership, 2, group: group)
+      BucketService.send_bucket_created_emails(bucket: bucket)
+      email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
+      expect(email_recipients.length).to eq(5)
+      expect(email_recipients).not_to include(user.email)      
     end
   end
 end

--- a/spec/services/comment_service_spec.rb
+++ b/spec/services/comment_service_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 describe "CommentService" do
   describe "#send_new_comment_emails(comment: )" do
     before do
-      @bucket_author = bucket.user
-      @comment = create(:comment, bucket: bucket)
+      @membership = make_user_group_member
+      @bucket = create(:bucket, group: group, user: user)
+      @bucket_author = user
+      @comment = create(:comment, bucket: @bucket)
       @comment_author = @comment.user
     end
 
@@ -14,7 +16,6 @@ describe "CommentService" do
 
     context "bucket author subscribed to personal activity" do
       it "bucket author receives notification email" do
-        @bucket_author.update(subscribed_to_personal_activity: true)
         CommentService.send_new_comment_emails(comment: @comment)
         email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
         expect(email_recipients).to include(@bucket_author.email)
@@ -28,6 +29,15 @@ describe "CommentService" do
         email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
         expect(email_recipients).not_to include(@bucket_author.email)
       end
+    end
+
+    context "bucket author no longer member of group" do
+      it "bucket author does not receive notification email" do
+        @membership.update(archived_at: DateTime.now.utc - 5.days)
+        CommentService.send_new_comment_emails(comment: @comment)
+        email_recipients = ActionMailer::Base.deliveries.map { |e| e.to.first }
+        expect(email_recipients).not_to include(@bucket_author.email)
+      end      
     end
   end
 end

--- a/spec/services/membership_service_spec.rb
+++ b/spec/services/membership_service_spec.rb
@@ -120,5 +120,13 @@ describe "MembershipService" do
 
       expect(@group.balance).to eq(30)
     end
+
+    context "after archiving, user has no more active memberships" do
+      it "sets user's archived_at to current time in utc" do
+        @other_membership.update(archived_at: DateTime.now.utc)
+        MembershipService.archive_membership(membership: @membership)
+        expect(@user.reload.archived_at).to be_truthy
+      end
+    end
   end
 end

--- a/spec/services/membership_service_spec.rb
+++ b/spec/services/membership_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe "MembershipService" do
-  describe "#delete_membership(membership: )" do
+  describe "#archive_membership(membership: )" do
     before do
       @group = create(:group)
       @user = create(:user)
@@ -11,14 +11,14 @@ describe "MembershipService" do
     end
 
     it "destroys membership" do
-      MembershipService.delete_membership(membership: @membership)
+      MembershipService.archive_membership(membership: @membership)
       expect(Membership.find_by_id(@membership.id)).to be_nil
     end
 
     it "destroys all member's draft buckets within the membership's group" do
       create_list(:bucket, 3, user: @user, status: 'draft', group: @group)
 
-      MembershipService.delete_membership(membership: @membership)
+      MembershipService.archive_membership(membership: @membership)
 
       expect(Bucket.where(group: @group).length).to eq(0)
     end
@@ -52,7 +52,7 @@ describe "MembershipService" do
       expect(membership2.balance).to eq(20)
 
       ActionMailer::Base.deliveries.clear
-      MembershipService.delete_membership(membership: @membership)
+      MembershipService.archive_membership(membership: @membership)
       sent_emails = ActionMailer::Base.deliveries
       user_1_email = sent_emails.find { |e| e.to[0] == user1.email }
       user_2_email = sent_emails.find { |e| e.to[0] == user2.email }
@@ -76,7 +76,7 @@ describe "MembershipService" do
       create(:allocation, user: @user, group: @group, amount: 200)
       create_list(:contribution, 3, user: @user, bucket: live_group_bucket, amount: 30)
 
-      MembershipService.delete_membership(membership: @membership)
+      MembershipService.archive_membership(membership: @membership)
 
       expect(live_group_bucket.contributions.length).to eq(0)
     end
@@ -109,7 +109,7 @@ describe "MembershipService" do
       expect(@group.balance).to eq(40)
 
       # delete membership service called
-      MembershipService.delete_membership(membership: @membership)
+      MembershipService.archive_membership(membership: @membership)
 
       # funded bucket should still have 2 contributions, totalling to 100
       expect(funded_bucket.contributions.length).to eq(2)
@@ -124,7 +124,7 @@ describe "MembershipService" do
 
     context "user has more than one membership" do
       it "does not destroy member" do
-        MembershipService.delete_membership(membership: @membership)
+        MembershipService.archive_membership(membership: @membership)
 
         expect(User.find_by_id(@user.id)).to be_truthy        
       end
@@ -133,7 +133,7 @@ describe "MembershipService" do
     context "user has only one membership" do
       it "also destroys member" do
         @other_membership.destroy
-        MembershipService.delete_membership(membership: @membership)
+        MembershipService.archive_membership(membership: @membership)
 
         expect(User.find_by_id(@user.id)).to be_nil
       end

--- a/spec/services/membership_service_spec.rb
+++ b/spec/services/membership_service_spec.rb
@@ -120,13 +120,5 @@ describe "MembershipService" do
 
       expect(@group.balance).to eq(30)
     end
-
-    context "after archiving, user has no more active memberships" do
-      it "sets user's archived_at to current time in utc" do
-        @other_membership.update(archived_at: DateTime.now.utc)
-        MembershipService.archive_membership(membership: @membership)
-        expect(@user.reload.archived_at).to be_truthy
-      end
-    end
   end
 end

--- a/spec/services/membership_service_spec.rb
+++ b/spec/services/membership_service_spec.rb
@@ -6,13 +6,12 @@ describe "MembershipService" do
       @group = create(:group)
       @user = create(:user)
       @membership = create(:membership, member: @user, group: @group)
-
       @other_membership = create(:membership, member: @user)
     end
 
-    it "destroys membership" do
+    it "archives membership" do
       MembershipService.archive_membership(membership: @membership)
-      expect(Membership.find_by_id(@membership.id)).to be_nil
+      expect(Membership.find_by_id(@membership).archived_at).to be_truthy
     end
 
     it "destroys all member's draft buckets within the membership's group" do
@@ -120,23 +119,6 @@ describe "MembershipService" do
       expect(live_bucket.contributions.sum(:amount)).to eq(20)
 
       expect(@group.balance).to eq(30)
-    end
-
-    context "user has more than one membership" do
-      it "does not destroy member" do
-        MembershipService.archive_membership(membership: @membership)
-
-        expect(User.find_by_id(@user.id)).to be_truthy        
-      end
-    end
-
-    context "user has only one membership" do
-      it "also destroys member" do
-        @other_membership.destroy
-        MembershipService.archive_membership(membership: @membership)
-
-        expect(User.find_by_id(@user.id)).to be_nil
-      end
     end
   end
 end


### PR DESCRIPTION
API partner to #262

satisfies expectations outlined in https://trello.com/c/jx2xKA0T/181-5-remove-user-2

brief summary:

- `User#destroy` destroys all trace of user via `dependent: :destroy`s (to be used if necessary)
- archive `membership`s instead of `destroy`ing them
- modify `MembershipsController` `GET` routes to return only `active` memberships
- email notifications only sent to `active` members
- replace `Users#create` route with `Users#invite_to_create_group` route
- distinguish between `initialized` and un`initialized` groups during `invite_to_create_group` user flow
- added / backfilled specs for every bit of code i touched