### PR TITLE
Bug/confirm account logs in wrong user

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -34,6 +34,6 @@ class GroupsController < AuthenticatedController
 
   private
     def group_params
-      params.require(:group).permit(:name, :currency_code)
+      params.require(:group).permit(:name, :currency_code, :initialized)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < AuthenticatedController
 
   api :POST, '/users/confirm_account'
   def confirm_account
+    render status: 400, nothing: true and return unless valid_confirm_account_params?
     if user = User.find_by_confirmation_token(params[:confirmation_token])
       user.update(name: params[:name], password: params[:password], confirmation_token: nil)
       render json: [user]
@@ -68,5 +69,9 @@ class UsersController < AuthenticatedController
         :subscribed_to_participant_activity,
         :confirmation_token
       )
+    end
+
+    def valid_confirm_account_params?
+      params[:confirmation_token].present? && params[:name].present? && params[:password].present?
     end
 end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -16,6 +16,7 @@ module MyLetDeclarations
   # HTTP status codes
   let(:success) { 200 }
   let(:created) { 201 }
+  let(:bad_request) { 400 }
   let(:unauthorized) { 401 }
   let(:forbidden) { 403 }
   let(:conflict) { 409 }


### PR DESCRIPTION
trello ticket: https://trello.com/c/gldibv08/396-2-confirm-account-form-bug-allows-users-to-log-in-as-other-users
partner UI PR: https://github.com/cobudget/cobudget-ui/pull/273

this feels like a **bug of the year** or something lol -- actually a combination of two bugs.

---

### it's storytime yall:

when a user is invited to create their own group via the `invite group` btn on the `admin-page`, a temporary, uninitialized group is created, and the user is sent an email inviting them to 1. setup their account and 2. setup their group.

so the user clicks the link in the email and sets up their account with a name and a password. great. things are looking great. then they set up their group with a name and are redirected to the group page. things are still looking great, and the user proceeds to visit the admin page and add some friends to their new group.

**but the group was never initialized**

---

so at this point one of the admin's friends has received their invite email, and have clicked on the 'get started' link. they submit their desired `name` and `password` into the `confirm-account` form and nothing seems to happen. the loading screen just keeps loading and loading.

here's what's happening in the background:

```coffeescript
      Records.users.confirmAccount(params)
        .then (data) ->
          user = data.users[0]
          global.cobudgetApp.currentUserId = user.id
          loginParams = { email: user.email, password: formData.password }
          $auth.submitLogin(loginParams)
            .then (ev, user) ->
              if $scope.groupId
                $location.path("/groups/#{$scope.groupId}/setup")
        .catch ->
          Toast.show('Sorry, that confirmation token has expired.')
          $location.path('/')
```

when the `confirm-account` form is submitted, a `confirm_account` request is made. when that request succeeds (and it does), a `submit_login` request is made. this request, too, succeeds. and when it does the following event handler is called:

```coffeescript
$rootScope.$on 'auth:login-success', (ev, user) ->
    global.cobudgetApp.currentUserId = user.id
    Records.memberships.fetchMyMemberships().then (data) ->
      membershipsLoadedDeferred.resolve()

      # if user has no groups, log user out, display error dialog, and redirect home
      if !data.groups
        $auth.signOut().then ->
          global.cobudgetApp.currentUserId = null
          $location.path('/')
          Dialog.alert(title: 'error!', content: 'invalid credentials!')
          LoadBar.stop()

      # if user has groups, and every group is initialized, redirect to group page
      # with toast, set timezone, and confirm user if necessary
      if data.groups && _.every(data.groups, {'initialized': true})
        groupId = data.groups[0].id
        $location.path("/groups/#{groupId}")
        Toast.show('Welcome to Cobudget!')
        if CurrentUser().utcOffset != moment().utcOffset()
          Records.users.updateProfile(utc_offset: moment().utcOffset())
        if CurrentUser().isPendingConfirmation
          Records.users.updateProfile(confirmationToken: null)
```

since the group was never initialized, the second conditional does not pass, and no promises are resolved, and the loading screen never stops. so the user gets impatient and refreshes the page.

**but when they refresh the page, their confirmation_token is no longer present in the url**

in the code's previous state, i'd decided to remove the `confirmation_token` from the url params immediately after the `confirm-account` form was submitted. this was a silly idea

---

so now the `confirm-account` page is reloaded and the user submits the form again with their desired `name` and `password`. everything seems to work out! 

but hold on, they're logged in as a different user? yeah, heres why:

```ruby
  api :POST, '/users/confirm_account'
  def confirm_account
    if user = User.find_by_confirmation_token(params[:confirmation_token])
      user.update(name: params[:name], password: params[:password], confirmation_token: nil)
      render json: [user]
    else
      render status: 403, nothing: true
    end
  end
```

when their second request is made, no `confirmation_token` is present in the url params. so in the above controller action, `params[:confirmation_token]` returns `nil`.

so now when `user = User.find_by_confirmation_token(params[:confirmation_token])` executes, it gets the first user it can find who doesn't have a `confirmation_token` (aka a random user who's account is already confirmed) and assigns them to `user`. this `user` is passed back to the UI, and now the user is logged in as some other random person.

**fuuuuuuuuuuuuck**

### storytime over

---

anyways, in this PR and the partner UI PR linked above, i've fixed the above bugs.

- users cannot make a confirm account request without specifying a confirmation_token, name, and password. if they attempt to, the server says 'NO' and returns http status `400`
- when a new group admin sets up their group via the `invite new user to create group` flow, the group is initialized on form submission.
- on the `confirm-account` page, url params are cleared only after a successful form submission.





