### PR TITLE
Bug/user can edit any bucket

### DIFF
--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -1,6 +1,6 @@
 class BucketsController < AuthenticatedController
   api :GET, '/buckets?group_id'
-  def index 
+  def index
     group = Group.find(params[:group_id])
     render json: group.buckets
   end
@@ -17,7 +17,7 @@ class BucketsController < AuthenticatedController
     if bucket.save
       # BucketService.send_bucket_created_emails(bucket: bucket)
       render json: [bucket]
-    else 
+    else
       render json: {
         errors: bucket.errors.full_messages
       }, status: 400
@@ -27,6 +27,7 @@ class BucketsController < AuthenticatedController
   api :PATCH, '/buckets/:id', 'Update a bucket'
   def update
     bucket = Bucket.find(params[:id])
+    render status: 403, nothing: true and return unless bucket.is_editable_by?(current_user)
     bucket.update_attributes(bucket_params_update)
     if bucket.save
       render json: [bucket]

--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -37,11 +37,6 @@ class BucketsController < AuthenticatedController
     end
   end
 
-  api :DELETE, '/buckets/:id', 'Deletes a bucket'
-  def destroy
-    destroy_resource
-  end
-
   api :POST, '/buckets/:id?target&funding_closes_at'
   def open_for_funding
     bucket = Bucket.find(params[:id])

--- a/app/controllers/buckets_controller.rb
+++ b/app/controllers/buckets_controller.rb
@@ -47,12 +47,10 @@ class BucketsController < AuthenticatedController
 
   private
     def bucket_params_create
-      # TODO: put user_id back in once we have a concept of 'current_user' in the API
       params.require(:bucket).permit(:name, :description, :group_id, :target).merge(user_id: current_user.id)
     end
 
     def bucket_params_update
-      # TODO: put user_id back in once we have a concept of 'current_user' in the API
-      params.require(:bucket).permit(:name, :description, :target) 
+      params.require(:bucket).permit(:name, :description, :target)
     end
 end

--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -47,7 +47,7 @@ class Bucket < ActiveRecord::Base
   end
 
   def description_as_markdown
-    renderer = Redcarpet::Render::HTML.new 
+    renderer = Redcarpet::Render::HTML.new
     markdown = Redcarpet::Markdown.new(renderer, extensions = {})
     markdown.render(description).html_safe
   end
@@ -75,6 +75,10 @@ class Bucket < ActiveRecord::Base
   def author_name
     membership = user.membership_for(group)
     membership.archived? ? "[removed user]" : user.name
+  end
+
+  def is_editable_by?(member)
+    member.is_admin_for?(group) || user == member
   end
 
   private

--- a/spec/controllers/buckets_controller_spec.rb
+++ b/spec/controllers/buckets_controller_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe BucketsController, type: :controller do
+  describe "#update" do
+    let!(:bucket) { create(:bucket) }
+    let!(:group) { bucket.group }
+    let(:bucket_params) {{
+      id: bucket.id,
+      bucket: {
+        name: "new name",
+        description: "new description",
+        target: 420
+      }
+    }}
+
+    context "user logged in" do
+      before { request.headers.merge!(user.create_new_auth_token) }
+
+      context "current_user is member of bucket's group" do
+        before { group.add_member(user) }
+
+        context "current_user is bucket author" do
+          before do
+            bucket.update(user: user)
+            patch :update, bucket_params
+            bucket.reload
+          end
+
+          it "returns http status ok" do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "updates bucket" do
+            expect(bucket.name).to eq("new name")
+          end
+        end
+
+        context "current_user is admin" do
+          before do
+            group.add_admin(user)
+            patch :update, bucket_params
+            bucket.reload
+          end
+
+          it "returns http status ok" do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "updates bucket" do
+            expect(bucket.name).to eq("new name")
+          end
+        end
+
+        context "current_user is neither an admin or bucket author" do
+          before do
+            patch :update, bucket_params
+            bucket.reload
+          end
+
+          it "returns http status forbidden" do
+            expect(response).to have_http_status(:forbidden)
+          end
+
+          it "does not update the bucket" do
+            expect(bucket.description).not_to eq("new description")
+          end
+        end
+      end
+
+      context "current_user not member of bucket's group" do
+        before do
+          patch :update, bucket_params
+          bucket.reload
+        end
+
+        it "returns http status forbidden" do
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "does not update the bucket" do
+          expect(bucket.description).not_to eq("new description")
+        end
+      end
+    end
+
+    context "user not logged in" do
+      before do
+        patch :update, bucket_params
+      end
+
+      it "returns http status unauthorized" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "does not update the bucket" do
+        expect(bucket.description).not_to eq("new description")
+      end
+    end
+  end
+end

--- a/spec/extras/deliver_daily_email_digest_spec.rb
+++ b/spec/extras/deliver_daily_email_digest_spec.rb
@@ -19,13 +19,13 @@ describe "DeliverDailyEmailDigest" do
       auckland_user_2 = create(:user, utc_offset: +720)
 
       # all are members of the same group
-      User.all.each { |user| create(:membership, group: group, member: user) }      
+      User.all.each { |user| create(:membership, group: group, member: user) }
 
       # and just an hour ago, there was some recent activity in the group!
       Timecop.freeze(@current_utc_time - 1.hour) do
-        create(:draft_bucket, group: group) # a new idea was made
-        create(:live_bucket, group: group) # an idea started its funding phase
-        create(:funded_bucket, group: group) # and a funding bucket became fully funded
+        create(:bucket, group: group, status: "draft") # a new idea was made
+        create(:bucket, group: group, status: "live") # an idea started its funding phase
+        create(:bucket, group: group, status: "fundedl") # and a funding bucket became fully funded
       end
     end
 
@@ -41,7 +41,7 @@ describe "DeliverDailyEmailDigest" do
         @sent_emails = ActionMailer::Base.deliveries
         @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
 
-        expect(@recipient_email_addresses.length).to eq(2)      
+        expect(@recipient_email_addresses.length).to eq(2)
         expect(@recipient_email_addresses).to include(@parisian_user_1.email)
         expect(@recipient_email_addresses).to include(@parisian_user_2.email)
       end
@@ -61,7 +61,7 @@ describe "DeliverDailyEmailDigest" do
           @recipient_email_addresses = @sent_emails.map { |e| e.to.first }
 
           # only 1 email is sent to parisian user 2
-          expect(@recipient_email_addresses.length).to eq(1)    
+          expect(@recipient_email_addresses.length).to eq(1)
           expect(@recipient_email_addresses).not_to include(@parisian_user_1.email)
           expect(@recipient_email_addresses).to include(@parisian_user_2.email)
           # because the server has no idea that parisian user 1 is in paris
@@ -94,7 +94,7 @@ describe "DeliverDailyEmailDigest" do
         Timecop.freeze(@current_utc_time) do
           DeliverDailyEmailDigest.to_subscribers!
           sent_emails = ActionMailer::Base.deliveries
-          expect(sent_emails.length).to eq(0)    
+          expect(sent_emails.length).to eq(0)
         end
       end
     end

--- a/spec/factories/buckets.rb
+++ b/spec/factories/buckets.rb
@@ -6,31 +6,11 @@ FactoryGirl.define do
     user
     target 500
     status 'live'
-  end
 
-  factory :funded_bucket, class: Bucket do
-    name { Faker::Lorem.sentence }
-    description { Faker::Lorem.paragraph }
-    group
-    user
-    target 500
-    status 'funded'
-  end
-
-  factory :live_bucket, class: Bucket do
-    name { Faker::Lorem.sentence }
-    description { Faker::Lorem.paragraph }
-    group
-    user
-    target 500
-    status 'live'
-  end
-
-  factory :draft_bucket, class: Bucket do
-    name { Faker::Lorem.sentence }
-    description { Faker::Lorem.paragraph }
-    group
-    user
-    status 'draft'
+    after(:create) do |bucket|
+      group = bucket.group
+      author = bucket.user
+      group.add_member(author) unless author.is_member_of?(group)
+    end
   end
 end

--- a/spec/services/bucket_service_spec.rb
+++ b/spec/services/bucket_service_spec.rb
@@ -8,7 +8,7 @@ describe "BucketService" do
   describe "#send_bucket_live_emails(bucket:)" do
     before do
       make_user_group_member
-      bucket = create(:live_bucket, user: user, group: group)
+      bucket = create(:bucket, user: user, group: group, status: "live")
       @bucket_author = bucket.user
 
       # create member with $100.00, who has subscribed to participant activity + has commented on bucket
@@ -40,7 +40,7 @@ describe "BucketService" do
     it "sends emails to all bucket participants subscribed to participant activity, whose membership in the group is active, except bucket author" do
       expect(@emails.length).to eq(2)
       expect(@email_recipients).to include(@subscribed_participant_with_balance.email)
-      expect(@email_recipients).to include(@subscribed_participant_without_balance.email)      
+      expect(@email_recipients).to include(@subscribed_participant_without_balance.email)
 
       expect(@email_recipients).not_to include(@bucket_author.email)
       expect(@email_recipients).not_to include(@unsubscribed_participant.email)
@@ -62,7 +62,7 @@ describe "BucketService" do
   describe "#send_bucket_funded_emails" do
     before do
       make_user_group_member
-      @bucket = create(:funded_bucket, user: user, group: group)
+      @bucket = create(:bucket, user: user, group: group, status: "funded")
       @bucket_author = @bucket.user
 
       # create member with $100.00, who has subscribed to participant activity + has commented on bucket
@@ -123,7 +123,7 @@ describe "BucketService" do
   describe "#send_bucket_created_emails(bucket:)" do
     it "sends emails to all active group members, except creator" do
       make_user_group_member
-      bucket = create(:draft_bucket, user: user, group: group)
+      bucket = create(:bucket, user: user, group: group, status: "draft")
       create_list(:membership, 5, group: group)
       create_list(:archived_membership, 2, group: group)
       BucketService.send_bucket_created_emails(bucket: bucket)

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -11,27 +11,27 @@ describe "UserService" do
         oakland_6am_yesterday_in_utc = oakland_6am_today_in_utc - 1.day
 
         Timecop.freeze(oakland_6am_yesterday_in_utc - 1.hours) do
-          create(:draft_bucket, group: group)
-          create(:live_bucket, group: group)
-          create(:funded_bucket, group: group)
+          create(:bucket, group: group, status: "draft")
+          create(:bucket, group: group, status: "live")
+          create(:bucket, group: group, status: "funded")
         end
 
         Timecop.freeze(oakland_6am_yesterday_in_utc + 2.hours) do
-          @d1 = create(:draft_bucket, group: group)
-          @l1 = create(:live_bucket, group: group)
-          @f1 = create(:funded_bucket, group: group)
+          @d1 = create(:bucket, group: group, status: "draft")
+          @l1 = create(:bucket, group: group, status: "live")
+          @f1 = create(:bucket, group: group, status: "funded")
         end
 
         Timecop.freeze(oakland_6am_yesterday_in_utc + 3.hours) do
-          @d2 = create(:draft_bucket, group: group)
-          @l2 = create(:live_bucket, group: group)
-          @f2 = create(:funded_bucket, group: group)
+          @d2 = create(:bucket, group: group, status: "draft")
+          @l2 = create(:bucket, group: group, status: "live")
+          @f2 = create(:bucket, group: group, status: "funded")
         end
 
         Timecop.freeze(oakland_6am_today_in_utc + 1.hours) do
-          create(:draft_bucket, group: group)
-          create(:live_bucket, group: group)
-          create(:funded_bucket, group: group)
+          create(:bucket, group: group, status: "draft")
+          create(:bucket, group: group, status: "live")
+          create(:bucket, group: group, status: "funded")
         end
 
         @recent_activity = UserService.fetch_recent_activity_for(user: user)
@@ -51,17 +51,17 @@ describe "UserService" do
 
       it "returns all draft buckets created between 6am yesterday and 6am today (user's local time)" do
         expect(@recent_activity[0][:draft_buckets].length).to eq(2)
-        expect(@recent_activity[0][:draft_buckets]).to include(@d1, @d2) 
-      end 
+        expect(@recent_activity[0][:draft_buckets]).to include(@d1, @d2)
+      end
 
       it "returns all buckets that became live between 6am yesterday and 6am today (user's local time)" do
         expect(@recent_activity[0][:live_buckets].length).to eq(2)
-        expect(@recent_activity[0][:live_buckets]).to include(@l1, @l2) 
+        expect(@recent_activity[0][:live_buckets]).to include(@l1, @l2)
       end
 
       it "returns all buckets that became funded between 6am yesterday and 6am today (user's local time)" do
         expect(@recent_activity[0][:funded_buckets].length).to eq(2)
-        expect(@recent_activity[0][:funded_buckets]).to include(@f1, @f2) 
+        expect(@recent_activity[0][:funded_buckets]).to include(@f1, @f2)
       end
     end
 
@@ -79,15 +79,15 @@ describe "UserService" do
         group2 = membership2.group
 
         Timecop.freeze(oakland_6am_yesterday_in_utc + 2.hours) do
-          create(:draft_bucket, group: group1)
-          create(:live_bucket, group: group1)
-          create(:funded_bucket, group: group1)
+          create(:bucket, group: group1, status: "draft")
+          create(:bucket, group: group1, status: "live")
+          create(:bucket, group: group1, status: "funded")
         end
 
         Timecop.freeze(oakland_6am_yesterday_in_utc + 3.hours) do
-          create(:draft_bucket, group: group2)
-          create(:live_bucket, group: group2)
-          create(:funded_bucket, group: group2)
+          create(:bucket, group: group2, status: "draft")
+          create(:bucket, group: group2, status: "live")
+          create(:bucket, group: group2, status: "funded")
         end
 
         @recent_activity = UserService.fetch_recent_activity_for(user: user)
@@ -112,15 +112,15 @@ describe "UserService" do
         group2 = membership2.group
 
         Timecop.freeze(oakland_6am_yesterday_in_utc + 2.hours) do
-          create(:draft_bucket, group: group1)
-          create(:live_bucket, group: group1)
-          create(:funded_bucket, group: group1)
+          create(:bucket, group: group1, status: "draft")
+          create(:bucket, group: group1, status: "live")
+          create(:bucket, group: group1, status: "funded")
         end
 
         Timecop.freeze(oakland_6am_yesterday_in_utc + 3.hours) do
-          create(:draft_bucket, group: group2)
-          create(:live_bucket, group: group2)
-          create(:funded_bucket, group: group2)
+          create(:bucket, group: group2, status: "draft")
+          create(:bucket, group: group2, status: "live")
+          create(:bucket, group: group2, status: "funded")
         end
 
         @recent_activity = UserService.fetch_recent_activity_for(user: user)


### PR DESCRIPTION
trello ticket: https://trello.com/c/Gh6ZgL4f/334-1-unauthorized-user-can-visit-edit-bucket-page-by-entering-in-bucket-bucketid-edit
partner UI PR: https://github.com/cobudget/cobudget-ui/pull/274

---

in this PR:
- `current_user` can only edit buckets via  `buckets#update` if they are an admin of the bucket's group or the author of the bucket.
- refactored `Bucket` factory, and added `after(:create)` callback that ensures bucket's user is a member of the bucket's group
- removed some old comments and actions from `BucketsController`