### PR TITLE
Feature/user can change account info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,44 @@
-# Cobudget API
+# cobudget-api
 
-[![Build Status](https://travis-ci.org/open-app/cobudget-api.svg?branch=master)](https://travis-ci.org/open-app/cobudget-api) [![Stories in Ready](https://badge.waffle.io/open-app/cobudget-api.png?label=ready&title=Ready)](https://waffle.io/open-app/cobudget-api)
+[![Build Status](https://travis-ci.org/cobudget/cobudget-api.svg?branch=master)](https://travis-ci.org/open-app/cobudget-api)
+[![Code Climate](https://codeclimate.com/github/cobudget/cobudget-api/badges/gpa.svg)](https://codeclimate.com/github/cobudget/cobudget-api)
 
-Cobudget is a web app helping people collaborate on budgets. For more about the project as a whole, check out the [top-level repo](https://github.com/open-app/cobudget). This repo is the backend API of Cobudget.
+cobudget's backend api. for more information on the project as a whole, check out the [top-level repo](https://github.com/cobudget/cobudget)
 
-#### Don't push to master - feature branches and pull requests please.
+**don't push to master - feature branches and pull requests please.**
 
-## How to...
+---
 
-### Install
-
-Install ruby and gem: https://www.ruby-lang.org/en/installation/
+### install
 
 ```
-git clone https://github.com/open-app/cobudget-api
+git clone https://github.com/cobudget/cobudget-api
 cd cobudget-api
 bundle install
-```
 
-Install [MailCatcher](http://mailcatcher.me/)
-
-```
 gem install mailcatcher
 mailcatcher
 ```
 
-and visit: http://localhost:1080/
+### configure
 
-### Configure
+edit `config/database.yml`.
 
-To configure database environments, edit `config/database.yml`.
-
-### Setup database
-
-*Setup and seed the db:*
+### setup
 
 ```
 bundle exec rake db:setup
+bundle exec rake db:seed
+bundle exec rake jobs:work
 ```
 
-### Run
-
-*Start rails server:*
+### run
 
 ```
 bundle exec rails s
 ```
 
-*Start Workers*
-
-```
-rake jobs:work
-```
-
-### Test
-
-*Test*
+### test
 
 ```
 bundle exec rspec

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -62,6 +62,7 @@ class UsersController < AuthenticatedController
   private
     def user_params
       params.require(:user).permit(
+        :name,
         :email,
         :utc_offset,
         :subscribed_to_personal_activity,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,7 @@ class UsersController < AuthenticatedController
     end
   end
 
+  # ahhh fuck this is actually really sketchy
   api :POST, '/users/reset_password?password&confirm_password&reset_password_token'
   def reset_password
     if params[:reset_password_token] && params[:password] && params[:password] == params[:confirm_password]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,7 +45,6 @@ class UsersController < AuthenticatedController
     end
   end
 
-  # ahhh fuck this is actually really sketchy
   api :POST, '/users/reset_password?password&confirm_password&reset_password_token'
   def reset_password
     if params[:reset_password_token] && params[:password] && params[:password] == params[:confirm_password]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -59,6 +59,7 @@ class UsersController < AuthenticatedController
     end
   end
 
+  # TODO: refactor into service 
   api :POST, '/users/update_password?current_password&password&confirm_password'
   def update_password
     render status: 401, nothing: true and return unless valid_update_password_params?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -62,15 +62,13 @@ class UsersController < AuthenticatedController
   api :POST, '/users/update_password?current_password&password&confirm_password'
   def update_password
     render status: 401, nothing: true and return unless valid_update_password_params?
-    if current_user.valid_password?(params[:current_password])
-      if params[:password] == params[:confirm_password]
-        current_user.update(password: params[:password])
-        render status: 200, nothing: true
-      else
-        render status: 400, json: { error: "passwords do not match" }
-      end
+    render status: 401, json: { errors: ["current_password is incorrect"] } and return unless current_user.valid_password?(params[:current_password])
+    render status: 400, json: { errors: ["passwords do not match"] } and return unless params[:password] == params[:confirm_password]
+    current_user.update(password: params[:password])
+    if current_user.valid?
+      render status: 200, nothing: true
     else
-      render status: 401, json: { error: "current_password is incorrect" }
+      render status: 400, json: { errors: current_user.errors.full_messages }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,7 +61,7 @@ class UsersController < AuthenticatedController
 
   api :POST, '/users/update_password?current_password&password&confirm_password'
   def update_password
-    render status: 403, nothing: true and return unless valid_update_password_params?
+    render status: 401, nothing: true and return unless valid_update_password_params?
     if current_user.valid_password?(params[:current_password])
       if params[:password] == params[:confirm_password]
         current_user.update(password: params[:password])

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -2,7 +2,7 @@ class AllocationService
   def self.create_allocations_from_csv(csv: , group: , current_user:)
     csv.each do |email, amount|
       email = email.downcase.strip
-      amount = amount.to_f
+      amount = amount.to_s.gsub(",", "").to_f
 
       if user = User.find_by_email(email)
         if user.is_member_of?(group)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
         post :reset_password
         post :update_profile
         post :invite_to_create_group
+        post :update_password
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -359,8 +359,8 @@ describe UsersController, :type => :controller do
           post :update_password, {current_password: "", password: "420blazeit", confirm_password: "420blazeit"}
         end
 
-        it "returns http status bad request" do
-          expect(response).to have_http_status(:forbidden)
+        it "returns http status unauthorized" do
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 


### PR DESCRIPTION
trello ticket: https://trello.com/c/NSJAfDyf/378-5-user-can-change-account-info
partner UI PR: https://github.com/cobudget/cobudget-ui/pull/276

---

in this PR:
- allowed `name` in `user_params`, so that name can be updated via the UI's `account-info-page`
- built and tested `users#update` route, requiring a `current_password`, `password`, and `confirm_password` so that password can be updated via the UI's `change-password-dialog`

---

some of these controller actions are getting a bit dense. sometime in the nearer future, it'd be good to refactor most of the controller logic into services (on the advice of @robguthrie)