### PR TITLE
remove commas from amounts in uploaded csv

### DIFF
--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -2,7 +2,7 @@ class AllocationService
   def self.create_allocations_from_csv(csv: , group: , current_user:)
     csv.each do |email, amount|
       email = email.downcase.strip
-      amount = amount.to_f
+      amount = amount.to_s.gsub(",", "").to_f
 
       if user = User.find_by_email(email)
         if user.is_member_of?(group)


### PR DESCRIPTION
charley davenport was uploading a csv for enspiral services that contained 'comma'-ed amounts i.e. `1,319.00`.

i forgot that this would be a totally common thing for anyone who uses spreadsheets to do -- i've updated the code to take amounts, and 1. convert them to a string, 2. strip all commas, 3. convert to a float.

i'll merge this immediately and deploy to `production`