### PR TITLE
Refactor/round down decimals

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,7 +3,7 @@ class UserMailer < ActionMailer::Base
     @user = user
     @group = group
     @inviter = inviter
-    @initial_allocation_amount = initial_allocation_amount
+    @initial_allocation_amount = initial_allocation_amount.floor
     @initial_allocation_amount_formatted = Money.new(initial_allocation_amount * 100, @group.currency_code).format
     mail(to: @user.name_and_email,
         from: "Cobudget Accounts <accounts@cobudget.co>",
@@ -14,7 +14,7 @@ class UserMailer < ActionMailer::Base
     @user = user
     @inviter = inviter
     @group = group
-    @initial_allocation_amount = initial_allocation_amount
+    @initial_allocation_amount = initial_allocation_amount.floor
     @initial_allocation_amount_formatted = Money.new(initial_allocation_amount * 100, @group.currency_code).format
     mail(to: @user.name_and_email,
         from: "Cobudget Accounts <accounts@cobudget.co>",

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -21,19 +21,17 @@ class Group < ActiveRecord::Base
   end
 
   def balance
-    allocation_sum = allocations.sum(:amount)
-    contribution_sum = buckets.map { |b| b.total_contributions }.reduce(:+) || 0
-    allocation_sum - contribution_sum
+    memberships.map { |m| m.balance }.reduce(:+) || 0
   end
 
   def formatted_balance
     Money.new(balance * 100, currency_code).format
   end
 
-  private 
+  private
     def update_currency_symbol_if_currency_code_changed
       if self.currency_code
         self.currency_symbol = Money.new(0, self.currency_code).symbol
-      end      
+      end
     end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -20,7 +20,7 @@ class Membership < ActiveRecord::Base
   end
 
   def balance
-    total_allocations - total_contributions
+    (total_allocations - total_contributions).floor
   end
 
   def formatted_balance

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -1,10 +1,9 @@
 class MembershipSerializer < ActiveModel::Serializer
   embed :ids, include: true
-  attributes :id, 
-             :is_admin, 
-             :created_at, 
-             :total_allocations, 
-             :total_contributions
+  attributes :id,
+             :is_admin,
+             :created_at,
+             :balance
              :archived_at
 
   has_one :member, serializer: UserSerializer, root: 'users'

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -5,7 +5,7 @@ class AllocationService
       amount = amount.to_s.gsub(",", "").to_f
 
       if user = User.find_by_email(email)
-        if user.is_member_of?(group)
+        if user.is_member_of?(group) && amount >= 1
           UserMailer.notify_member_that_they_received_allocation(admin: current_user, member: user, group: group, amount: amount).deliver_later if amount > 0
         else
           group.add_member(user)

--- a/app/views/user_mailer/notify_member_that_they_received_allocation.html.erb
+++ b/app/views/user_mailer/notify_member_that_they_received_allocation.html.erb
@@ -4,4 +4,4 @@
 
 <p>
   <%= link_to 'View or Submit Projects', "#{root_url}#/groups/#{@group.id}" %>
- </p>
+</p>

--- a/db/migrate/20160211044338_round_down_decimal_contributions_on_funding_buckets.rb
+++ b/db/migrate/20160211044338_round_down_decimal_contributions_on_funding_buckets.rb
@@ -1,0 +1,29 @@
+class RoundDownDecimalContributionsOnFundingBuckets < ActiveRecord::Migration
+  def up
+    # for all currently funding buckets
+    Bucket.where(status: "live").each do |bucket|
+      group = bucket.group
+
+      bucket.contributions.each do |contribution|
+        user = contribution.user
+        amount = contribution.amount
+        rounded_down_amount = amount.to_i
+        difference = amount - rounded_down_amount
+
+        # if contribution amount is non-integer
+        if difference > 0
+          if rounded_down_amount > 0
+            # if rounded_down_amount is greater than zero, round down contribution's amount
+            contribution.update(amount: rounded_down_amount)
+          else
+            # if rounded_down_amount is zero, destroy contribution
+            contribution.destroy
+          end
+          
+          # give difference back to user
+          Allocation.create(group: group, user: user, amount: difference)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20160211050430_contribution_amounts_and_bucket_targets_must_be_integers.rb
+++ b/db/migrate/20160211050430_contribution_amounts_and_bucket_targets_must_be_integers.rb
@@ -1,0 +1,11 @@
+class ContributionAmountsAndBucketTargetsMustBeIntegers < ActiveRecord::Migration
+  def up
+    change_column :contributions, :amount, :integer, null: false
+    change_column :buckets, :target, :integer
+  end
+
+  def down
+    change_column :contributions, :amount, :decimal, precision: 12, scale: 2, null: false
+    change_column :buckets, :target, :decimal, precision: 12, scale: 2
+  end
+end

--- a/db/migrate/20160211052541_remove_default_amounts_for_contributions_and_allocations.rb
+++ b/db/migrate/20160211052541_remove_default_amounts_for_contributions_and_allocations.rb
@@ -1,0 +1,13 @@
+class RemoveDefaultAmountsForContributionsAndAllocations < ActiveRecord::Migration
+  def up
+    change_column_default :allocations, :amount, nil
+    change_column_default :contributions, :amount, nil
+    change_column_null :allocations, :amount, false
+  end
+
+  def down
+    change_column_default :allocations, :amount, 0
+    change_column_default :contributions, :amount, 0.0
+    change_column_null :allocations, :amount, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160202055141) do
+ActiveRecord::Schema.define(version: 20160211052541) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20160202055141) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
-    t.decimal  "amount",     precision: 12, scale: 2, default: 0.0
+    t.decimal  "amount",     precision: 12, scale: 2, null: false
     t.integer  "group_id"
   end
 
@@ -33,9 +33,9 @@ ActiveRecord::Schema.define(version: 20160202055141) do
     t.string   "name"
     t.text     "description"
     t.integer  "user_id"
-    t.decimal  "target",            precision: 12, scale: 2
+    t.integer  "target"
     t.integer  "group_id"
-    t.string   "status",                                     default: "draft"
+    t.string   "status",            default: "draft"
     t.datetime "funding_closes_at"
     t.datetime "funded_at"
     t.datetime "live_at"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 20160202055141) do
     t.integer  "bucket_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.decimal  "amount",     precision: 12, scale: 2, default: 0.0
+    t.integer  "amount",     null: false
   end
 
   add_index "contributions", ["bucket_id"], name: "index_contributions_on_bucket_id", using: :btree

--- a/spec/extras/deliver_daily_email_digest_spec.rb
+++ b/spec/extras/deliver_daily_email_digest_spec.rb
@@ -56,7 +56,7 @@ describe "DeliverDailyEmailDigest" do
           @parisian_user_1_email = @sent_emails.find { |e| e.to.first == @parisian_user_1.email }
           @parisian_user_2_email = @sent_emails.find { |e| e.to.first == @parisian_user_2.email }
           expect(@parisian_user_1_email.body.raw_source).not_to include("You have $0.00 to spend")
-          expect(@parisian_user_2_email.body.raw_source).to include("You have $4.20 to spend")
+          expect(@parisian_user_2_email.body.raw_source).to include("You have $4.00 to spend")
         end
       end
     end


### PR DESCRIPTION
partner UI PR: https://github.com/cobudget/cobudget-ui/pull/283
trello card: https://trello.com/c/7RnrJ6EF/456-3-round-down-everything

we've decided to require that bucket targets and contribution amounts must be integers. allocations, however, can be decimal amounts. 

we've also decided that on the UI, a member can only see and use their rounded-down balance. so if a member has a balance of $10.80, they effectively only have $10.00. 

in this PR and its partner API PR, said changes are implemented.

### on the API:

- i've written migrations that take all contributions on live buckets, rounds them down, and gives the difference back to said contributors. bucket targets and contributions are thereafter set as integers instead of decimals.
- `Membership#balance` now returns the membership's floored `balance`
- 'Group#balance` now returns the sum of its memberships' floored `balance`s
- email notifications re: funds / balances, mention them as integers, not floats

### on the UI:

- create/edit bucket forms, and funding form only accept positive integers

