### PR TITLE
Addresses CSV upload bug when bucket has archived users also contained

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,4 +1,5 @@
 require 'csv'
+require 'pry'
 
 class AllocationsController < AuthenticatedController
   api :GET, '/allocations?group_id=', 'Get allocations for a particular group'
@@ -12,14 +13,9 @@ class AllocationsController < AuthenticatedController
     file = params[:csv].tempfile
     csv = CSV.read(file)
     group = Group.find(params[:group_id])
-    errors = []
-    ActiveRecord::Base.transaction do
-      errors = AllocationService.create_allocations_from_csv(csv: csv, group: group, current_user: current_user)
-      if errors
-        raise ActiveRecord::Rollback
-      end
-    end
-    if errors
+    errors = AllocationService.create_allocations_from_csv(csv: csv, group: group, current_user: current_user)
+
+    if not errors.empty?
       render json: {errors: errors}, status: 409
     else
       render nothing: true, status: 200

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -13,9 +13,8 @@ class AllocationsController < AuthenticatedController
     file = params[:csv].tempfile
     csv = CSV.read(file)
     group = Group.find(params[:group_id])
-    errors = AllocationService.create_allocations_from_csv(csv: csv, group: group, current_user: current_user)
 
-    if not errors.empty?
+    if errors = AllocationService.create_allocations_from_csv(csv: csv, group: group, current_user: current_user)
       render json: {errors: errors}, status: 409
     else
       render nothing: true, status: 200

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -34,9 +34,7 @@ class AllocationService
         Allocation.create(group: group, user: user, amount: amount)
       end # each
 
-      if not errors.empty?
-        raise ActiveRecord::Rollback
-      end
+      raise ActiveRecord::Rollback unless errors.empty?
     end
     errors if errors.any?
   end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -1,35 +1,42 @@
 class AllocationService
   def self.create_allocations_from_csv(csv: , group: , current_user:)
     errors = []
-    csv.each do |email, amount|
-      email = email.downcase.strip
-      amount = amount.to_s.gsub(",", "").to_f
+    ActiveRecord::Base.transaction do
 
-      if user = User.find_by_email(email)
-        if user.membership_for(group).archived?
-          errors << email + " is no longer an active member."
-          next
-        end
+      csv.each do |email, amount|
+        email = email.downcase.strip
+        amount = amount.to_s.gsub(",", "").to_f
 
-        if user.is_member_of?(group)
-          UserMailer.notify_member_that_they_received_allocation(admin: current_user, member: user, group: group, amount: amount).deliver_later if amount > 0
-        else
-          begin
-            group.add_member(user)
-          rescue ActiveRecord::RecordInvalid => e
-            if e.message == 'Validation failed: Member has already been taken'
-              errors << user.email + ' ' + e.message
-              next
-            end
+        if user = User.find_by_email(email)
+          if user.membership_for(group).archived?
+            errors << email + " is no longer an active member."
+            next
           end
-          UserMailer.invite_to_group_email(user: user, inviter: current_user, group: group, initial_allocation_amount: amount).deliver_later
+
+          if user.is_member_of?(group)
+            UserMailer.notify_member_that_they_received_allocation(admin: current_user, member: user, group: group, amount: amount).deliver_later if amount > 0
+          else
+            begin
+              group.add_member(user)
+            rescue ActiveRecord::RecordInvalid => e
+              if e.message == 'Validation failed: Member has already been taken'
+                errors << user.email + ' ' + e.message
+                next
+              end
+            end
+            UserMailer.invite_to_group_email(user: user, inviter: current_user, group: group, initial_allocation_amount: amount).deliver_later
+          end
+        else
+          user = User.create_with_confirmation_token(email: email)
+          group.add_member(user)
+          UserMailer.invite_email(user: user, group: group, inviter: current_user, initial_allocation_amount: amount).deliver_later if user.valid?
         end
-      else
-        user = User.create_with_confirmation_token(email: email)
-        group.add_member(user)
-        UserMailer.invite_email(user: user, group: group, inviter: current_user, initial_allocation_amount: amount).deliver_later if user.valid?
+        Allocation.create(group: group, user: user, amount: amount)
+      end # each
+
+      if not errors.empty?
+        raise ActiveRecord::Rollback
       end
-      Allocation.create(group: group, user: user, amount: amount)
     end
     errors
   end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -1,14 +1,27 @@
 class AllocationService
   def self.create_allocations_from_csv(csv: , group: , current_user:)
+    errors = []
     csv.each do |email, amount|
       email = email.downcase.strip
       amount = amount.to_s.gsub(",", "").to_f
 
       if user = User.find_by_email(email)
+        if user.membership_for(group).archived?
+          errors << email + " is no longer an active member."
+          next
+        end
+
         if user.is_member_of?(group)
           UserMailer.notify_member_that_they_received_allocation(admin: current_user, member: user, group: group, amount: amount).deliver_later if amount > 0
         else
-          group.add_member(user)
+          begin
+            group.add_member(user)
+          rescue ActiveRecord::RecordInvalid => e
+            if e.message == 'Validation failed: Member has already been taken'
+              errors << user.email + ' ' + e.message
+              next
+            end
+          end
           UserMailer.invite_to_group_email(user: user, inviter: current_user, group: group, initial_allocation_amount: amount).deliver_later
         end
       else
@@ -16,8 +29,8 @@ class AllocationService
         group.add_member(user)
         UserMailer.invite_email(user: user, group: group, inviter: current_user, initial_allocation_amount: amount).deliver_later if user.valid?
       end
-
       Allocation.create(group: group, user: user, amount: amount)
     end
+    errors
   end
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -38,6 +38,6 @@ class AllocationService
         raise ActiveRecord::Rollback
       end
     end
-    errors
+    errors if errors.any?
   end
 end

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -7,12 +7,18 @@ RSpec.describe AllocationsController, type: :controller do
       request.headers.merge!(user.create_new_auth_token)
     end
 
-    it "fails with errors when uploading csv" do
+    it "succeeds when uploading csv" do
+      # upload a csv file containing that user's email address
+      post :upload, {group_id: @membership.group.id, csv: fixture_file_upload('test-csv.csv', 'text/csv')}
+      expect(response).to have_http_status(200)
+    end
+
+    it "fails with errors when uploading csv with archived members" do
       # create an archived member of the group
       participant = create(:user, email: 'gbickford@gmail.com')
-      create(:membership, member: participant, group: @membership.group)      
+      create(:membership, member: participant, group: @membership.group)
       Membership.find_by(group: group, member: participant).update(archived_at: DateTime.now.utc - 5.days)
-      
+
       # upload a csv file containing that user's email address
       post :upload, {group_id: @membership.group.id, csv: fixture_file_upload('test-csv.csv', 'text/csv')}
       expect(response).to have_http_status(409)

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe AllocationsController, type: :controller do
     end
 
     it "fails with errors when uploading csv" do
+      # create an archived member of the group
       participant = create(:user, email: 'gbickford@gmail.com')
       create(:membership, member: participant, group: @membership.group)      
       Membership.find_by(group: group, member: participant).update(archived_at: DateTime.now.utc - 5.days)
       
+      # upload a csv file containing that user's email address
       post :upload, {group_id: @membership.group.id, csv: fixture_file_upload('test-csv.csv', 'text/csv')}
-      puts parsed(response)["errors"][0]
       expect(response).to have_http_status(409)
       expect(parsed(response)["errors"][0]).to eq('gbickford@gmail.com is no longer an active member.')
     end

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe AllocationsController, type: :controller do
       request.headers.merge!(user.create_new_auth_token)
     end
 
+    it "fails with errors when uploading csv" do
+      participant = create(:user, email: 'gbickford@gmail.com')
+      create(:membership, member: participant, group: @membership.group)      
+      Membership.find_by(group: group, member: participant).update(archived_at: DateTime.now.utc - 5.days)
+      
+      post :upload, {group_id: @membership.group.id, csv: fixture_file_upload('test-csv.csv', 'text/csv')}
+      puts parsed(response)["errors"][0]
+      expect(response).to have_http_status(409)
+      expect(parsed(response)["errors"][0]).to eq('gbickford@gmail.com is no longer an active member.')
+    end
+
     context "valid params" do
       before do
         valid_params = {

--- a/spec/fixtures/test-csv.csv
+++ b/spec/fixtures/test-csv.csv
@@ -1,3 +1,4 @@
+gbickford@gmail.com,9001
 katrine_ebert@hermann.net,200
 lawrence.prosacco@gleasonbatz.net,145
 rupert.hodkiewicz@mcclure.info,647

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,9 @@ RSpec.configure do |config|
   # Helpers
   config.include Helpers
 
+  # for fixture_file_upload
+  config.include ActionDispatch::TestProcess
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe "AllocationService" do
+  after do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "#create_allocations_from_csv(csv: , group: , current_user:)" do
+    before do
+      @group = create(:group)
+      @admin_user = create(:user)
+      @admin_membership = create(:membership, member: @admin_user, group: @group, is_admin: true)
+      @bucket = create(:bucket, user: @admin_user, group: @group, status: "live")
+
+      @user = create(:user)
+      @membership = create(:membership, member: @user, group: @group)
+
+      # create an archived participant
+      @archived_participant = create_bucket_participant(bucket: @bucket, subscribed: true)
+      Membership.find_by(group: @bucket.group, member: @archived_participant).update(archived_at: DateTime.now.utc - 5.days)
+
+      @archived_participant2 = create_bucket_participant(bucket: @bucket, subscribed: true)
+      Membership.find_by(group: @bucket.group, member: @archived_participant2).update(archived_at: DateTime.now.utc - 5.days)
+
+    end
+
+    it "uploads new allocations via csv" do
+      csv = CSV.read("./spec/fixtures/test-csv.csv")
+
+      AllocationService.create_allocations_from_csv(csv: csv, group: @group, current_user: @admin_user)
+      kat = User.find_by(email: "katrine_ebert@hermann.net")
+      expect(kat).to be_truthy
+      expect(@group.memberships.find_by(member: kat)).to be_truthy
+    end
+
+    it "returns errors when csv contains archived member(s)" do
+      csv = CSV.read("./spec/fixtures/test-csv.csv")
+      
+      csv << [@archived_participant[:email], "9000"]
+      csv << [@archived_participant2[:email], "9000"]
+      csv << ["gbickford@gmail.com", "9000"]
+
+      errors = []
+      ActiveRecord::Base.transaction do
+        errors = AllocationService.create_allocations_from_csv(csv: csv, group: @group, current_user: @admin_user)
+        expect(errors).not_to be_empty
+        if errors
+          raise ActiveRecord::Rollback
+        end
+      end
+      gardner_user = User.find_by(email: "gbickford@gmail.com")
+      expect(gardner_user).not_to be_truthy
+
+      archived_user = User.find_by(email: @archived_participant[:email])
+      expect(archived_user).to be_truthy
+
+      errors
+    end
+
+  end
+end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -28,6 +28,7 @@ describe "AllocationService" do
       csv = CSV.read("./spec/fixtures/test-csv.csv")
 
       if errors = AllocationService.create_allocations_from_csv(csv: csv, group: @group, current_user: @admin_user)
+        # fail if there are any errors
         expect(errors).to be_empty
       end
 
@@ -43,6 +44,7 @@ describe "AllocationService" do
       csv << [@archived_participant2[:email], "9000"]
       csv << ["gbickford@gmail.com", "9000"]
 
+      # there is no if statement here to ensure that expect() is called.
       errors = AllocationService.create_allocations_from_csv(csv: csv, group: @group, current_user: @admin_user)
       expect(errors).not_to be_empty
 


### PR DESCRIPTION
Addresses CSV upload bug when bucket has archived users also contained in CSV. This upload process is now wrapped in an ActiveRecord transaction. If an admin attempts to upload a CSV file that contains an email address for an archived user, an http 409 error is returned along with json data including a list of offending email addresses.

[Trello Card](https://trello.com/c/DooSu94X/472-when-you-upload-a-list-of-members-and-some-of-them-are-archived-it-fails-to-update)

