### PR TITLE
in Bucket#author_name, return removed user if no membership exists

### DIFF
--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -74,7 +74,7 @@ class Bucket < ActiveRecord::Base
 
   def author_name
     membership = user.membership_for(group)
-    membership.archived? ? "[removed user]" : user.name
+    !membership || membership.archived? ? "[removed user]" : user.name
   end
 
   def is_editable_by?(member)


### PR DESCRIPTION
small fix to address the bug described in this [trello card](https://trello.com/c/GQAglrsq/469-cors-error-when-trying-to-load-group-30)

i think what's happened here is .. before we formalized our `remove-member` feature , we were just deleting memberships haphazardly lol. this was prolly done directly in the api's console. 

