### PR TITLE
Hotfix/better csv upload

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -12,13 +12,16 @@ class AllocationsController < AuthenticatedController
     file = params[:csv].tempfile
     parsed_csv = CSV.read(file)
     group = Group.find(params[:group_id])
-    AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
-    
-    if errors =
-      render json: {errors: errors}, status: 409
-    else
-      render nothing: true, status: 200
-    end
+
+    render nothing: true, status: 403 and return unless current_user.is_admin_for?(group)
+
+    status = AllocationService.create_allocations_from_csv(
+      parsed_csv: parsed_csv,
+      group: group,
+      current_user: current_user
+    ) ? 200 : 422
+
+    render nothing: true, status: status
   end
 
   api :POST, '/allocations?membership_id&amount'

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -10,10 +10,11 @@ class AllocationsController < AuthenticatedController
   api :POST, '/allocations/upload?group_id='
   def upload
     file = params[:csv].tempfile
-    csv = CSV.read(file)
+    parsed_csv = CSV.read(file)
     group = Group.find(params[:group_id])
-
-    if errors = AllocationService.create_allocations_from_csv(csv: csv, group: group, current_user: current_user)
+    AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
+    
+    if errors =
       render json: {errors: errors}, status: 409
     else
       render nothing: true, status: 200

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -31,6 +31,18 @@ class Membership < ActiveRecord::Base
     archived_at
   end
 
+  def active?
+    !archived?
+  end
+
+  def archive!
+    update(archived_at: DateTime.now.utc)
+  end
+
+  def reactivate!
+    update(archived_at: nil)
+  end
+
   private
     def currency_code
       group.currency_code

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -1,41 +1,43 @@
 class AllocationService
-  def self.create_allocations_from_csv(csv: , group: , current_user:)
-    errors = []
+  def self.create_allocations_from_csv(parsed_csv: , group: , current_user:)
+    upload_success = true
+    emails = []
+
     ActiveRecord::Base.transaction do
+      begin
+        parsed_csv.each do |email, amount|
+          email = email.downcase.strip
+          amount = amount.to_s.gsub(",", "").to_f
 
-      csv.each do |email, amount|
-        email = email.downcase.strip
-        amount = amount.to_s.gsub(",", "").to_f
-
-        if user = User.find_by_email(email)
-          if user.membership_for(group) && user.membership_for(group).archived?
-            errors << email + " is no longer an active member."
-            next
-          end
-
-          if user.is_member_of?(group) && amount >= 1
-            UserMailer.notify_member_that_they_received_allocation(admin: current_user, member: user, group: group, amount: amount).deliver_later if amount > 0
-          else
-            begin
-              group.add_member(user)
-            rescue ActiveRecord::RecordInvalid => e
-              if e.message == 'Validation failed: Member has already been taken'
-                errors << user.email + ' ' + e.message
-                next
+          if user = User.find_by_email(email)
+            if membership = user.membership_for(group)
+              if membership.archived?
+                membership.reactivate!
+                emails << UserMailer.invite_to_group_email(user: user, inviter: current_user, group: group, initial_allocation_amount: amount)
+              else
+                emails << UserMailer.notify_member_that_they_received_allocation(admin: current_user, member: user, group: group, amount: amount) if amount >= 1
               end
+            else
+              group.add_member(user)
+              emails << UserMailer.invite_to_group_email(user: user, inviter: current_user, group: group, initial_allocation_amount: amount)
             end
-            UserMailer.invite_to_group_email(user: user, inviter: current_user, group: group, initial_allocation_amount: amount).deliver_later
+          else
+            user = User.create_with_confirmation_token(email: email)
+            group.add_member(user)
+            emails << UserMailer.invite_email(user: user, group: group, inviter: current_user, initial_allocation_amount: amount) if user.valid?
           end
-        else
-          user = User.create_with_confirmation_token(email: email)
-          group.add_member(user)
-          UserMailer.invite_email(user: user, group: group, inviter: current_user, initial_allocation_amount: amount).deliver_later if user.valid?
-        end
-        Allocation.create(group: group, user: user, amount: amount)
-      end # each
 
-      raise ActiveRecord::Rollback unless errors.empty?
+          Allocation.create(group: group, user: user, amount: amount)
+        end
+      rescue
+        upload_success = false
+      end
+      if upload_success
+        emails.each { |email| email.deliver_later }
+      else
+        raise ActiveRecord::Rollback unless upload_success
+      end
     end
-    errors if errors.any?
+    upload_success
   end
 end

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -22,6 +22,6 @@ class MembershipService
     Allocation.create(user: member, group: group, amount: -membership.balance)
 
     # archive membership
-    membership.update(archived_at: DateTime.now.utc)
+    membership.archive!
   end
 end

--- a/app/views/user_mailer/invite_email.html.erb
+++ b/app/views/user_mailer/invite_email.html.erb
@@ -15,5 +15,3 @@
 <p>
   <%= link_to "See how it works", "https://docs.google.com/presentation/d/1ZQYKxhHwKuQGmOMPpoE8Eo0XMuw1yn55Bjgsh6-D0eQ/present?slide=id.p" %> and <%= link_to "get started", "#{root_url}#/confirm_account?confirmation_token=#{@user.confirmation_token}"%>.
 </p>
-
-  

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -1,36 +1,117 @@
 require 'rails_helper'
 
 RSpec.describe AllocationsController, type: :controller do
-  context "user is group admin" do
-    before do
-      @membership = make_user_group_admin
-      request.headers.merge!(user.create_new_auth_token)
-    end
+  let(:valid_csv) { fixture_file_upload('test-csv.csv', 'text/csv') }
+  let(:totally_fucked_csv) { fixture_file_upload('totally-fucked-csv.csv', 'text/csv') }
 
-    it "succeeds when uploading csv" do
-      # upload a csv file containing that user's email address
-      post :upload, {group_id: @membership.group.id, csv: fixture_file_upload('test-csv.csv', 'text/csv')}
-      expect(response).to have_http_status(200)
-    end
-
-    it "fails with errors when uploading csv with archived members" do
-      # create an archived member of the group
-      participant = create(:user, email: 'gbickford@gmail.com')
-      create(:membership, member: participant, group: @membership.group)
-      Membership.find_by(group: group, member: participant).update(archived_at: DateTime.now.utc - 5.days)
-
-      # upload a csv file containing that user's email address
-      post :upload, {group_id: @membership.group.id, csv: fixture_file_upload('test-csv.csv', 'text/csv')}
-      expect(response).to have_http_status(409)
-      expect(parsed(response)["errors"][0]).to eq('gbickford@gmail.com is no longer an active member.')
-    end
-
-    context "valid params" do
+  describe "#upload" do
+    context "user is group admin" do
       before do
+        @membership = make_user_group_admin
+        request.headers.merge!(user.create_new_auth_token)
+      end
+
+      context "csv is properly formatted" do
+        it "returns http status 'ok'" do
+          post :upload, {group_id: @membership.group.id, csv: valid_csv}
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "csv is fucked" do
+        it "returns http status 'unprocessable'" do
+          post :upload, {group_id: @membership.group.id, csv: totally_fucked_csv}
+          expect(response).to have_http_status(422)
+        end
+      end
+    end
+
+    context "user is not group admin" do
+      before do
+        membership = make_user_group_member
+        request.headers.merge!(user.create_new_auth_token)
+        post :upload, {group_id: membership.group_id, csv: valid_csv}
+      end
+
+      it "returns http status 'forbidden'" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "user is not logged in" do
+      it "returns http status 'unauthorized'" do
+        membership = make_user_group_member
+        post :create, {membership_id: membership.id, amount: 420}
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+  end
+
+  describe "#create" do
+    context "user is group admin" do
+      before do
+        @membership = make_user_group_admin
+        request.headers.merge!(user.create_new_auth_token)
+      end
+
+      context "valid params" do
+        before do
+          valid_params = {
+            allocation: {
+              group_id: @membership.group.id,
+              user_id: @membership.member.id,
+              amount: 420
+            }
+          }
+          post :create, valid_params
+          @found_allocation = Allocation.find_by(valid_params[:allocation])
+        end
+
+        it "creates allocation with specified params" do
+          expect(@found_allocation).to be_truthy
+        end
+
+        it "returns allocation as json" do
+          expect(parsed(response)["allocations"][0]["id"]).to eq(@found_allocation.id)
+        end
+
+        it "returns http status 'created'" do
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      context "invalid params" do
+        before do
+          invalid_params = {
+            allocation: {
+              group_id: @membership.group.id,
+              user_id: @membership.member.id,
+              amount: 0
+            }
+          }
+          post :create, invalid_params
+          @found_allocation = Allocation.find_by(invalid_params[:allocation])
+        end
+
+        it "does not create an allocation" do
+          expect(@found_allocation).to be_nil
+        end
+
+        it "returns http status 400" do
+          expect(response).to have_http_status(400)
+        end
+      end
+    end
+
+    context "user is not group admin" do
+      before do
+        membership = make_user_group_member
+        request.headers.merge!(user.create_new_auth_token)
         valid_params = {
           allocation: {
-            group_id: @membership.group.id,
-            user_id: @membership.member.id,
+            group_id: membership.group.id,
+            user_id: membership.member.id,
             amount: 420
           }
         }
@@ -38,71 +119,21 @@ RSpec.describe AllocationsController, type: :controller do
         @found_allocation = Allocation.find_by(valid_params[:allocation])
       end
 
-      it "creates allocation with specified params" do
-        expect(@found_allocation).to be_truthy
-      end
-
-      it "returns allocation as json" do
-        expect(parsed(response)["allocations"][0]["id"]).to eq(@found_allocation.id)
-      end
-
-      it "returns http status 'created'" do
-        expect(response).to have_http_status(:created)
-      end
-    end
-
-    context "invalid params" do
-      before do
-        invalid_params = {
-          allocation: {
-            group_id: @membership.group.id,
-            user_id: @membership.member.id,
-            amount: 0
-          }
-        }
-        post :create, invalid_params
-        @found_allocation = Allocation.find_by(invalid_params[:allocation])
-      end
-
       it "does not create an allocation" do
         expect(@found_allocation).to be_nil
       end
 
-      it "returns http status 400" do
-        expect(response).to have_http_status(400)
+      it "returns http status 'forbidden'" do
+        expect(response).to have_http_status(:forbidden)
       end
     end
-  end
 
-  context "user is not group admin" do
-    before do
-      membership = make_user_group_member
-      request.headers.merge!(user.create_new_auth_token)
-      valid_params = {
-        allocation: {
-          group_id: membership.group.id,
-          user_id: membership.member.id,
-          amount: 420
-        }
-      }
-      post :create, valid_params
-      @found_allocation = Allocation.find_by(valid_params[:allocation])
-    end
-
-    it "does not create an allocation" do
-      expect(@found_allocation).to be_nil
-    end
-
-    it "returns http status 'forbidden'" do
-      expect(response).to have_http_status(:forbidden)
-    end
-  end
-
-  context "user not logged in" do
-    it "returns http status 'unauthorized'" do
-      membership = make_user_group_member
-      post :create, {membership_id: membership.id, amount: 420}
-      expect(response).to have_http_status(:unauthorized)
+    context "user not logged in" do
+      it "returns http status 'unauthorized'" do
+        membership = make_user_group_member
+        post :create, {membership_id: membership.id, amount: 420}
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end

--- a/spec/fixtures/totally-fucked-csv.csv
+++ b/spec/fixtures/totally-fucked-csv.csv
@@ -1,0 +1,3 @@
+real@email.address, 420
+,
+lol

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -1,61 +1,153 @@
 require "rails_helper"
 
+#
+# @group = create(:group)
+# @admin_user = create(:user)
+# @admin_membership = create(:membership, member: @admin_user, group: @group, is_admin: true)
+# @bucket = create(:bucket, user: @admin_user, group: @group, status: "live")
+#
+# @user = create(:user)
+# @membership = create(:membership, member: @user, group: @group)
+#
+# # create an archived participant
+# @archived_participant = create_bucket_participant(bucket: @bucket, subscribed: true)
+# Membership.find_by(group: @bucket.group, member: @archived_participant).update(archived_at: DateTime.now.utc - 5.days)
+#
+# @archived_participant2 = create_bucket_participant(bucket: @bucket, subscribed: true)
+# Membership.find_by(group: @bucket.group, member: @archived_participant2).update(archived_at: DateTime.now.utc - 5.days)
+#
+
+require "csv"
+
+def generate_parsed_csv_with_user(user: , allocation_amount: )
+  [[user.email, allocation_amount]]
+end
+
 describe "AllocationService" do
   after do
     ActionMailer::Base.deliveries.clear
   end
 
-  describe "#create_allocations_from_csv(csv: , group: , current_user:)" do
-    before do
-      @group = create(:group)
-      @admin_user = create(:user)
-      @admin_membership = create(:membership, member: @admin_user, group: @group, is_admin: true)
-      @bucket = create(:bucket, user: @admin_user, group: @group, status: "live")
+  describe "#create_allocations_from_csv(parsed_csv: , group: , current_user:)" do
+    let!(:current_user) { create(:user) }
+    let!(:group) { create(:group) }
 
-      @user = create(:user)
-      @membership = create(:membership, member: @user, group: @group)
+    context "user exists" do
+      let!(:user) { create(:user) }
 
-      # create an archived participant
-      @archived_participant = create_bucket_participant(bucket: @bucket, subscribed: true)
-      Membership.find_by(group: @bucket.group, member: @archived_participant).update(archived_at: DateTime.now.utc - 5.days)
+      context "membership exists, but is archived" do
+        let!(:archived_membership) { create(:archived_membership, member: user, group: group) }
 
-      @archived_participant2 = create_bucket_participant(bucket: @bucket, subscribed: true)
-      Membership.find_by(group: @bucket.group, member: @archived_participant2).update(archived_at: DateTime.now.utc - 5.days)
+        before do
+          parsed_csv = generate_parsed_csv_with_user(user: user, allocation_amount: 420)
+          AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
+        end
 
-    end
+        it "membership is reactivated" do
+          expect(archived_membership.reload.active?).to be_truthy
+        end
 
-    it "uploads new allocations via csv" do
-      csv = CSV.read("./spec/fixtures/test-csv.csv")
+        it "user receives 'invite to group' email" do
+          sent_email = ActionMailer::Base.deliveries.first
+          expect(sent_email.body.to_s).to include("#{current_user.name} has invited you to collaboratively budget with everyone else at #{group.name}. You've got $420.00 to spend!")
+        end
 
-      if errors = AllocationService.create_allocations_from_csv(csv: csv, group: @group, current_user: @admin_user)
-        # fail if there are any errors
-        expect(errors).to be_empty
+        it "user receives allocation" do
+          expect(Allocation.find_by(user: user, amount: 420, group: group)).to be_truthy
+        end
       end
 
-      kat = User.find_by(email: "katrine_ebert@hermann.net")
-      expect(kat).to be_truthy
-      expect(@group.memberships.find_by(member: kat)).to be_truthy
+      context "membership exists and is active" do
+        let!(:active_membership) { create(:membership, member: user, group: group)}
+
+        before do
+          parsed_csv = generate_parsed_csv_with_user(user: user, allocation_amount: 420)
+          AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
+        end
+
+        it "user receives 'allocation' email" do
+          sent_email = ActionMailer::Base.deliveries.first
+          expect(sent_email.body.to_s).to include("You’ve received $420.00 to fund projects with #{group.name} in Cobudget!")
+        end
+
+        it "user receives allocation" do
+          expect(Allocation.find_by(user: user, amount: 420, group: group)).to be_truthy
+        end
+      end
+
+      context "membership doesn't exist" do
+        before do
+          parsed_csv = generate_parsed_csv_with_user(user: user, allocation_amount: 420)
+          AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
+        end
+
+        it "user receives 'invite to group' email" do
+          sent_email = ActionMailer::Base.deliveries.first
+          expect(sent_email.body.to_s).to include("#{current_user.name} has invited you to collaboratively budget with everyone else at #{group.name}. You've got $420.00 to spend!")
+        end
+
+        it "membership created for user" do
+          expect(Membership.find_by(member: user, group: group)).to be_truthy
+        end
+
+        it "user receives allocation" do
+          expect(Allocation.find_by(user: user, amount: 420, group: group)).to be_truthy
+        end
+      end
     end
 
-    it "returns errors when csv contains archived member(s)" do
-      csv = CSV.read("./spec/fixtures/test-csv.csv")
+    context "user doesn't exist" do
+      before do
+        parsed_csv = [["fucking_doge_hat@com.com", 420]]
+        AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
+        @new_user = User.find_by_email("fucking_doge_hat@com.com")
+      end
 
-      csv << [@archived_participant[:email], "9000"]
-      csv << [@archived_participant2[:email], "9000"]
-      csv << ["gbickford@gmail.com", "9000"]
+      it "new_user created" do
+        expect(@new_user).to be_truthy
+      end
 
-      # there is no if statement here to ensure that expect() is called.
-      errors = AllocationService.create_allocations_from_csv(csv: csv, group: @group, current_user: @admin_user)
-      expect(errors).not_to be_empty
+      it "membership created" do
+        expect(Membership.find_by(member: @new_user, group: group)).to be_truthy
+      end
 
-      gardner_user = User.find_by(email: "gbickford@gmail.com")
-      expect(gardner_user).not_to be_truthy
+      it "new_user receives 'invite to cobudget' email" do
+        sent_email = ActionMailer::Base.deliveries.first
+        expect(sent_email.body.to_s).to include("You have been invited by #{current_user.name} to collaboratively fund with #{group.name} on Cobudget. You've got $420.00 to spend!")
+      end
 
-      archived_user = User.find_by(email: @archived_participant[:email])
-      expect(archived_user).to be_truthy
-
-      errors
+      it "new_user receives allocation" do
+        expect(Allocation.find_by(user: @new_user, group: group, amount: 420)).to be_truthy
+      end
     end
 
+    context "properly formatted csv" do
+      it "returns true" do
+        parsed_csv = [["fucking_doge_hat@com.com", 420]]
+        result = AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
+        expect(result).to be_truthy
+      end
+    end
+
+    context "fucked up csv" do
+      before do
+        parsed_csv = [["fucking_doge_hat@com.com", 420], [], ['lol']]
+        @result = AllocationService.create_allocations_from_csv(parsed_csv: parsed_csv, group: group, current_user: current_user)
+      end
+
+      it "sends no emails" do
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+
+      it "creates no records" do
+        expect(User.find_by_email("fucking_doge_hat@com.com")).to be_nil
+        expect(Membership.count).to eq(0)
+        expect(Allocation.count).to eq(0)
+      end
+
+      it "returns false" do
+        expect(@result).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
[partner UI PR](https://github.com/cobudget/cobudget-ui/pull/291)

jessy-kate was experiencing some issues with csv upload -- namely, when she was setting up a new group / inviting members / giving them funds, nothing was happening if there were archived members' email addresses in the csv. 

in #113, @gardner had made it so that the upload would be cancelled if there were any archived members' email addresses in the csv. this felt good to me at first. but then i thought -- wait, if there email is in the uploaded csv, shouldn't we be re-activating their membership and re-inviting them to the group?

in this API PR, i've updated the expectations of `AllocationService#create_allocations_from_csv` as follows:
![screen shot 2016-02-26 at 12 41 50 am](https://cloud.githubusercontent.com/assets/7520103/13348009/dedafb8e-dc25-11e5-81e3-541814bf7b00.png)

i've also updated the expectations of `AllocationsController#upload` as follows:
![screen shot 2016-02-26 at 1 13 38 am](https://cloud.githubusercontent.com/assets/7520103/13348080/40df4e3e-dc26-11e5-836a-5b9f11e0e1c8.png)


in the partner UI PR, i've made it so that if there are any errors (like a totally fucked csv), it will display an error message. before it was always displaying `upload complete` -- which is uhhh, not so good lol

--- 

i'm mergin this PR now, because we need some sort of fix immediately -- and i think this is a good one

at any time, we can discuss and implement alternative solutions @derekrazo @mixmix @gardner
