### PR TITLE
fix Bucket#formatted_percent_funded

### DIFF
--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -39,7 +39,7 @@ class Bucket < ActiveRecord::Base
   end
 
   def formatted_percent_funded
-    "#{((total_contributions / target).to_f * 100).round}%"
+    "#{(total_contributions.to_f / target * 100).round}%"
   end
 
   def num_of_comments

--- a/spec/models/bucket_spec.rb
+++ b/spec/models/bucket_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Bucket, :type => :model do
       user2 = create(:user)
       create(:contribution, bucket: bucket, user: user1)
       create(:contribution, bucket: bucket, user: user1)
-      create(:contribution, bucket: bucket, user: user2)   
+      create(:contribution, bucket: bucket, user: user2)
       expect(bucket.num_of_contributors).to eq(2)
     end
   end
@@ -45,6 +45,15 @@ RSpec.describe Bucket, :type => :model do
         bucket.update(status: 'funded')
         expect(bucket.funded_at).to be_truthy
       end
+    end
+  end
+
+  describe "#formatted_percent_funded" do
+    it "returns percent that the bucket has been funded, with no decimal places" do
+      bucket = create(:bucket, status: 'live', target: 100)
+      expect(bucket.formatted_percent_funded).to eq("0%")
+      create(:contribution, bucket: bucket, amount: 22)
+      expect(bucket.formatted_percent_funded).to eq("22%")
     end
   end
 end


### PR DESCRIPTION
when we moved towards integer-only contributions and bucket targets, the `Bucket` model's `#formatted_percent_funded` method started returning `"0%"` all the time, because it was expecting contribution amount's to be floats, not integers.

in this PR, i've fixed that method and added some specs

merging now