### PR TITLE
Bug/comments cannot be empty

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < AuthenticatedController
+  before_action :validate_user_is_group_member!
+
   api :GET, '/comments?bucket_id='
   def index
     bucket = Bucket.find(params[:bucket_id])
@@ -8,12 +10,26 @@ class CommentsController < AuthenticatedController
   api :POST, '/comments'
   def create
     comment = Comment.create(comment_params)
-    CommentService.send_new_comment_emails(comment: comment)
-    render json: [comment]
+    if comment.valid?
+      CommentService.send_new_comment_emails(comment: comment)
+      render json: [comment]
+    else
+      render nothing: true, status: 422
+    end
   end
 
   private
     def comment_params
       params.require(:comment).permit(:bucket_id, :body).merge(user_id: current_user.id)
+    end
+
+    def validate_user_is_group_member!
+      render nothing: true, status: 403 and return unless current_user.is_member_of?(group)
+    end
+
+    def group
+      return @group if @group
+      bucket_id = params[:bucket_id] || comment_params[:bucket_id]
+      @group = Bucket.find_by_id(bucket_id).group if bucket_id
     end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,6 +4,7 @@ class Comment < ActiveRecord::Base
 
   validates :user_id, presence: true
   validates :bucket_id, presence: true
+  validates :body, presence: true
 
   # add helper method to the UserMailer, takes an argument (text) returns rendered text
   def body_as_markdown

--- a/db/migrate/20160311035750_make_comment_body_mandatory.rb
+++ b/db/migrate/20160311035750_make_comment_body_mandatory.rb
@@ -1,0 +1,10 @@
+class MakeCommentBodyMandatory < ActiveRecord::Migration
+  def up
+    change_column :comments, :body, :string, null: false
+    Comment.where(body: nil).delete_all
+  end
+
+  def down
+    change_column :comments, :body, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160218191412) do
+ActiveRecord::Schema.define(version: 20160311035750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20160218191412) do
   add_index "buckets", ["user_id"], name: "index_buckets_on_user_id", using: :btree
 
   create_table "comments", force: :cascade do |t|
-    t.text     "body"
+    t.string   "body",       null: false
     t.integer  "user_id"
     t.integer  "bucket_id"
     t.datetime "created_at", null: false

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -2,4 +2,45 @@ require 'rails_helper'
 
 RSpec.describe CommentsController, type: :controller do
 
+  describe "#create" do
+    let(:valid_params) { {comment: {bucket_id: bucket.id, body: "hello dix"}} }
+    let(:invalid_params) { {comment: {bucket_id: bucket.id, body: ""}} }
+
+    context "user signed in" do
+      before { request.headers.merge!(user.create_new_auth_token) }
+
+      context "user member of group" do
+        before { make_user_group_member }
+
+        context "valid params" do
+          it "returns http status 'success'" do
+            post :create, valid_params
+            expect(response).to have_http_status(:success)
+          end
+        end
+
+        context "invalid params" do
+          it "returns http status 'unprocessable'" do
+            post :create, invalid_params
+            expect(response).to have_http_status(422)
+          end
+        end
+      end
+
+      context "user not member of group" do
+        it "returns http status 'forbidden'" do
+          post :create, valid_params
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context "user not signed in" do
+      it "returns http status 'unauthorized'" do
+        post :create, valid_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
[partner UI PR](https://github.com/cobudget/cobudget-ui/pull/302)
[trello card](https://trello.com/c/W5vcrKg6/420-blanked-and-maybe-duplicate-comments)

in this PR, i've added validations requiring a comment's body to be non-empty. i've also written a migration to delete all blank comments