### PR TITLE
Move Group balance calculation to Group model

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -51,8 +51,16 @@
     memberships.create!(member: user, is_admin: false)
   end
 
+  def total_allocations
+    allocations.sum(:amount)
+  end
+
+  def total_contributions
+    Contribution.where(bucket_id: buckets.map(&:id)).sum(:amount)
+  end
+
   def balance
-    memberships.map { |m| m.balance }.reduce(:+) || 0
+    (total_allocations - total_contributions).floor || 0
   end
 
   def formatted_balance

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Group, :type => :model do
-	describe "#add_admin(user)" do
+  describe "#add_admin(user)" do
     context "user already member of group" do
       it "makes the user an admin of group" do
-        make_user_group_member 
+        make_user_group_member
         group.add_admin(user)
         expect(group.memberships.find_by(member: user, is_admin: true)).to be_truthy
       end
@@ -16,15 +16,52 @@ RSpec.describe Group, :type => :model do
         user = create(:user)
         group.add_admin(user)
         expect(group.memberships.find_by(member: user, is_admin: true)).to be_truthy
-  		end
+      end
     end
-	end
+  end
 
-  describe "#balance" do
-    context "if no allocations or contributions" do
-      it "returns 0" do
-        group = create(:group)
-        expect(group.balance).to eq(0)
+  describe "group balance calculations" do
+    subject(:group)  { create(:group) }
+    let(:bucket) { create(:bucket, group: group) }
+
+    describe "#total_allocations" do
+      it "calculates all allocations" do
+        create(:allocation, group: group, amount: 100)
+        create(:allocation, group: group, amount: 100.5)
+        expect(subject.total_allocations).to eq 200.5
+      end
+    end
+
+    describe "#total_contributions" do
+      it "calculates all contributions" do
+        create(:contribution, bucket: bucket, amount: 100)
+        create(:contribution, bucket: bucket, amount: 100)
+        expect(subject.total_contributions).to eq 200
+      end
+    end
+
+    describe "#balance" do
+      context "if no allocations or contributions" do
+        it "returns 0" do
+          expect(subject.balance).to eq(0)
+        end
+      end
+
+      context "with allocations and contributions" do
+        it "calculates the group balance" do
+          create(:allocation, group: group, amount: 500)
+          create(:allocation, group: group, amount: 100)
+          create(:contribution, bucket: bucket, amount: 100)
+          create(:contribution, bucket: bucket, amount: 100)
+          # contribution factory creates an allocation equalling
+          # the contribution amount
+          expect(subject.reload.balance).to eq 600
+        end
+
+        it "rounds the balance down" do
+          create(:allocation, group: group, amount: 500.50)
+          expect(subject.reload.balance).to eq 500
+        end
       end
     end
   end


### PR DESCRIPTION
This should remove the query for every membership issue we are having on the groups page, by moving balance calculation from the Membership model into the Group model. 

I've tried to avoid changing the underlying structure of the app as much as possible, as I don't understand it all. I think the Group model could benefit from a relationship/interface to contributions, it feels a bit clunky to be reaching into Contributions directly from #total_contributions. But given time pressure with the conference this is hopefully a good initial refactoring. 