### PR TITLE
Don't load group in Membership#total_allocations, instead use group_id

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -11,7 +11,7 @@ class Membership < ActiveRecord::Base
   after_create :update_member_if_this_is_their_first_membership
 
   def total_allocations
-    group.allocations.where(user_id: member_id).sum(:amount)
+    Allocation.where(user_id: member_id, group_id: group_id).sum(:amount)
   end
 
   def total_contributions


### PR DESCRIPTION
This cuts the MembershipController#index processing time down a lot by skipping loading the group first, and directly using the group_id.

The Membership balance code should really be refactored into proper relations soon! It's pretty nasty currently.  