### PR TITLE
Enable super admins to browse all groups

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,9 @@ class User < ActiveRecord::Base
   end
 
   def is_member_of?(group)
+    if is_super_admin
+        return true
+    end
     Membership.where(group: group, member: self, archived_at: nil).length > 0
   end
 


### PR DESCRIPTION
create fake memberships for all groups a superadmin user is not already a part of, so that super admins can browse all groups.